### PR TITLE
Redesigned logging infrastructure for memflow plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,12 +109,12 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-04-08
+          toolchain: nightly-2021-12-01
           override: true
-      - run: rustup toolchain install nightly-2021-04-08
-      - run: rustup +nightly-2021-04-08 component add rust-src
+      - run: rustup toolchain install nightly-2021-12-01
+      - run: rustup +nightly-2021-12-01 component add rust-src
       - name: Build no_std crate
-        run: cd nostd-test; cargo +nightly-2021-04-08 build --all-features --verbose
+        run: cd nostd-test; cargo +nightly-2021-12-01 build --all-features --verbose
 
   build-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,12 +109,12 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-12-01
+          toolchain: nightly-2021-12-19
           override: true
-      - run: rustup toolchain install nightly-2021-12-01
-      - run: rustup +nightly-2021-12-01 component add rust-src
+      - run: rustup toolchain install nightly-2021-12-19
+      - run: rustup +nightly-2021-12-19 component add rust-src
       - name: Build no_std crate
-        run: cd nostd-test; cargo +nightly-2021-12-01 build --all-features --verbose
+        run: cd nostd-test; cargo +nightly-2021-12-19 build --all-features --verbose
 
   build-coverage:
     runs-on: ubuntu-latest

--- a/memflow-derive/src/lib.rs
+++ b/memflow-derive/src/lib.rs
@@ -86,7 +86,7 @@ pub fn connector(args: TokenStream, input: TokenStream) -> TokenStream {
                 args: &cglue::repr_cstring::ReprCString,
                 _: cglue::option::COption<#crate_path::os::root::OsInstanceArcBox>,
                 lib: #crate_path::cglue::CArc<::core::ffi::c_void>,
-                logger: #crate_path::plugins::PluginLogger,
+                logger: Option<&'static #crate_path::plugins::PluginLogger>,
                 out: &mut #crate_path::mem::phys_mem::MuConnectorInstanceArcBox<'static>
             ) -> i32 {
                 #crate_path::plugins::connector::create(args, lib, logger, out, #func_name)
@@ -197,7 +197,7 @@ pub fn os_layer(args: TokenStream, input: TokenStream) -> TokenStream {
                 args: &cglue::repr_cstring::ReprCString,
                 mem: #crate_path::cglue::COption<#crate_path::mem::phys_mem::ConnectorInstanceArcBox<'static>>,
                 lib: #crate_path::cglue::CArc<::core::ffi::c_void>,
-                logger: #crate_path::plugins::PluginLogger,
+                logger: Option<&'static #crate_path::plugins::PluginLogger>,
                 out: &mut #crate_path::os::root::MuOsInstanceArcBox<'static>
             ) -> i32 {
                 #crate_path::plugins::os::create(args, mem.into(), lib, logger, out, #func_name)
@@ -283,7 +283,7 @@ pub fn os_layer_bare(args: TokenStream, input: TokenStream) -> TokenStream {
             args: &cglue::repr_cstring::ReprCString,
             mem: #crate_path::cglue::COption<#crate_path::mem::phys_mem::ConnectorInstanceArcBox<'static>>,
             lib: #crate_path::cglue::CArc<::core::ffi::c_void>,
-            logger: #crate_path::plugins::PluginLogger,
+            logger: Option<&'static #crate_path::plugins::PluginLogger>,
             out: &mut #crate_path::os::root::MuOsInstanceArcBox<'static>
         ) -> i32 {
             #crate_path::plugins::create_bare(args, mem.into(), lib, logger, out, #func_name)

--- a/memflow-derive/src/lib.rs
+++ b/memflow-derive/src/lib.rs
@@ -80,32 +80,17 @@ pub fn connector(args: TokenStream, input: TokenStream) -> TokenStream {
     let func = parse_macro_input!(input as ItemFn);
     let func_name = &func.sig.ident;
 
-    let create_fn_gen = if func.sig.inputs.len() > 1 {
-        quote! {
+    let create_fn_gen = quote! {
             #[doc(hidden)]
             extern "C" fn mf_create(
                 args: &cglue::repr_cstring::ReprCString,
                 _: cglue::option::COption<#crate_path::os::root::OsInstanceArcBox>,
                 lib: #crate_path::cglue::CArc<::core::ffi::c_void>,
-                log_level: i32,
+                logger: #crate_path::plugins::PluginLogger,
                 out: &mut #crate_path::mem::phys_mem::MuConnectorInstanceArcBox<'static>
             ) -> i32 {
-                #crate_path::plugins::connector::create_with_logging(args, lib, log_level, out, #func_name)
+                #crate_path::plugins::connector::create(args, lib, logger, out, #func_name)
             }
-        }
-    } else {
-        quote! {
-            #[doc(hidden)]
-            extern "C" fn mf_create(
-                args: &cglue::repr_cstring::ReprCString,
-                _: cglue::option::COption<#crate_path::os::root::OsInstanceArcBox>,
-                lib: #crate_path::cglue::CArc<::core::ffi::c_void>,
-                _: i32,
-                out: &mut #crate_path::mem::phys_mem::MuConnectorInstanceArcBox<'static>
-            ) -> i32 {
-                #crate_path::plugins::connector::create_without_logging(args, lib, out, #func_name)
-            }
-        }
     };
 
     let help_fn_gen = args.help_fn.map(|v| v.parse().unwrap()).map_or_else(
@@ -206,32 +191,17 @@ pub fn os_layer(args: TokenStream, input: TokenStream) -> TokenStream {
     let func = parse_macro_input!(input as ItemFn);
     let func_name = &func.sig.ident;
 
-    let create_fn_gen = if func.sig.inputs.len() > 2 {
-        quote! {
+    let create_fn_gen = quote! {
             #[doc(hidden)]
             extern "C" fn mf_create(
                 args: &cglue::repr_cstring::ReprCString,
                 mem: #crate_path::cglue::COption<#crate_path::mem::phys_mem::ConnectorInstanceArcBox<'static>>,
                 lib: #crate_path::cglue::CArc<::core::ffi::c_void>,
-                log_level: i32,
+                logger: #crate_path::plugins::PluginLogger,
                 out: &mut #crate_path::os::root::MuOsInstanceArcBox<'static>
             ) -> i32 {
-                #crate_path::plugins::os::create_with_logging(args, mem.into(), lib, log_level, out, #func_name)
+                #crate_path::plugins::os::create(args, mem.into(), lib, logger, out, #func_name)
             }
-        }
-    } else {
-        quote! {
-            #[doc(hidden)]
-            extern "C" fn mf_create(
-                args: &cglue::repr_cstring::ReprCString,
-                mem: #crate_path::cglue::COption<#crate_path::mem::phys_mem::ConnectorInstanceArcBox<'static>>,
-                lib: #crate_path::cglue::CArc<::core::ffi::c_void>,
-                _: i32,
-                out: &mut #crate_path::os::root::MuOsInstanceArcBox<'static>
-            ) -> i32 {
-                #crate_path::plugins::os::create_without_logging(args, mem.into(), lib, out, #func_name)
-            }
-        }
     };
 
     let help_fn_gen = args.help_fn.map(|v| v.parse().unwrap()).map_or_else(
@@ -313,10 +283,10 @@ pub fn os_layer_bare(args: TokenStream, input: TokenStream) -> TokenStream {
             args: &cglue::repr_cstring::ReprCString,
             mem: #crate_path::cglue::COption<#crate_path::mem::phys_mem::ConnectorInstanceArcBox<'static>>,
             lib: #crate_path::cglue::CArc<::core::ffi::c_void>,
-            log_level: i32,
+            logger: #crate_path::plugins::PluginLogger,
             out: &mut #crate_path::os::root::MuOsInstanceArcBox<'static>
         ) -> i32 {
-            #crate_path::plugins::create_bare(args, mem.into(), lib, log_level, out, #func_name)
+            #crate_path::plugins::create_bare(args, mem.into(), lib, logger, out, #func_name)
         }
     };
 

--- a/memflow-ffi/cbindgen.toml
+++ b/memflow-ffi/cbindgen.toml
@@ -14,7 +14,7 @@ parse_deps = true
 include = ["memflow"]
 
 [parse.expand]
-crates = ["cglue", "memflow", "memflow-ffi"]
+crates = ["cglue", "memflow", "memflow-ffi", "log"]
 
 [macro_expansion]
 bitflags = true

--- a/memflow-ffi/memflow.h
+++ b/memflow-ffi/memflow.h
@@ -155,6 +155,98 @@ enum Endianess
 typedef uint8_t Endianess;
 #endif // __cplusplus
 
+/**
+ * An enum representing the available verbosity levels of the logger.
+ *
+ * Typical usage includes: checking if a certain `Level` is enabled with
+ * [`log_enabled!`](macro.log_enabled.html), specifying the `Level` of
+ * [`log!`](macro.log.html), and comparing a `Level` directly to a
+ * [`LevelFilter`](enum.LevelFilter.html).
+ */
+enum Level
+#ifdef __cplusplus
+  : uintptr_t
+#endif // __cplusplus
+ {
+    /**
+     * The "error" level.
+     *
+     * Designates very serious errors.
+     */
+    Level_Error = 1,
+    /**
+     * The "warn" level.
+     *
+     * Designates hazardous situations.
+     */
+    Level_Warn,
+    /**
+     * The "info" level.
+     *
+     * Designates useful information.
+     */
+    Level_Info,
+    /**
+     * The "debug" level.
+     *
+     * Designates lower priority information.
+     */
+    Level_Debug,
+    /**
+     * The "trace" level.
+     *
+     * Designates very low priority, often extremely verbose, information.
+     */
+    Level_Trace,
+};
+#ifndef __cplusplus
+typedef uintptr_t Level;
+#endif // __cplusplus
+
+/**
+ * An enum representing the available verbosity level filters of the logger.
+ *
+ * A `LevelFilter` may be compared directly to a [`Level`]. Use this type
+ * to get and set the maximum log level with [`max_level()`] and [`set_max_level`].
+ *
+ * [`Level`]: enum.Level.html
+ * [`max_level()`]: fn.max_level.html
+ * [`set_max_level`]: fn.set_max_level.html
+ */
+enum LevelFilter
+#ifdef __cplusplus
+  : uintptr_t
+#endif // __cplusplus
+ {
+    /**
+     * A level lower than all log levels.
+     */
+    LevelFilter_Off,
+    /**
+     * Corresponds to the `Error` log level.
+     */
+    LevelFilter_Error,
+    /**
+     * Corresponds to the `Warn` log level.
+     */
+    LevelFilter_Warn,
+    /**
+     * Corresponds to the `Info` log level.
+     */
+    LevelFilter_Info,
+    /**
+     * Corresponds to the `Debug` log level.
+     */
+    LevelFilter_Debug,
+    /**
+     * Corresponds to the `Trace` log level.
+     */
+    LevelFilter_Trace,
+};
+#ifndef __cplusplus
+typedef uintptr_t LevelFilter;
+#endif // __cplusplus
+
 typedef struct ArchitectureObj ArchitectureObj;
 
 /**
@@ -1848,9 +1940,29 @@ extern const struct ArchitectureObj *X86_32_PAE;
 
 extern const struct ArchitectureObj *X86_64;
 
-void log_init(int32_t level_num);
+/**
+ * Initialize logging with selected logging level.
+ */
+void log_init(LevelFilter level_filter);
 
+/**
+ * Logs an error with custom log level.
+ */
+void log_error(Level level, int32_t error);
+
+/**
+ * Logs an error with debug log level.
+ */
 void debug_error(int32_t error);
+
+/**
+ * Sets new maximum log level.
+ *
+ * If `inventory` is supplied, the log level is also updated within all plugin instances. However,
+ * if it is not supplied, plugins will not have their log levels updated, potentially leading to
+ * lower performance, or less logging than expected.
+ */
+void set_max_level(LevelFilter level_filter, const struct Inventory *inventory);
 
 /**
  * Helper to convert `Address` to a `PhysicalAddress`

--- a/memflow-ffi/memflow.h
+++ b/memflow-ffi/memflow.h
@@ -1948,12 +1948,12 @@ void log_init(LevelFilter level_filter);
 /**
  * Logs an error with custom log level.
  */
-void log_error(Level level, int32_t error);
+void log(Level level, int32_t error);
 
 /**
  * Logs an error with debug log level.
  */
-void debug_error(int32_t error);
+void log_debug_error(int32_t error);
 
 /**
  * Sets new maximum log level.
@@ -1962,7 +1962,7 @@ void debug_error(int32_t error);
  * if it is not supplied, plugins will not have their log levels updated, potentially leading to
  * lower performance, or less logging than expected.
  */
-void set_max_level(LevelFilter level_filter, const struct Inventory *inventory);
+void log_set_max_level(LevelFilter level_filter, const struct Inventory *inventory);
 
 /**
  * Helper to convert `Address` to a `PhysicalAddress`

--- a/memflow-ffi/memflow.hpp
+++ b/memflow-ffi/memflow.hpp
@@ -28,6 +28,84 @@ enum class Endianess : uint8_t {
     Endianess_BigEndian,
 };
 
+/**
+ * An enum representing the available verbosity levels of the logger.
+ *
+ * Typical usage includes: checking if a certain `Level` is enabled with
+ * [`log_enabled!`](macro.log_enabled.html), specifying the `Level` of
+ * [`log!`](macro.log.html), and comparing a `Level` directly to a
+ * [`LevelFilter`](enum.LevelFilter.html).
+ */
+enum class Level : uintptr_t {
+    /**
+     * The "error" level.
+     *
+     * Designates very serious errors.
+     */
+    Level_Error = 1,
+    /**
+     * The "warn" level.
+     *
+     * Designates hazardous situations.
+     */
+    Level_Warn,
+    /**
+     * The "info" level.
+     *
+     * Designates useful information.
+     */
+    Level_Info,
+    /**
+     * The "debug" level.
+     *
+     * Designates lower priority information.
+     */
+    Level_Debug,
+    /**
+     * The "trace" level.
+     *
+     * Designates very low priority, often extremely verbose, information.
+     */
+    Level_Trace,
+};
+
+/**
+ * An enum representing the available verbosity level filters of the logger.
+ *
+ * A `LevelFilter` may be compared directly to a [`Level`]. Use this type
+ * to get and set the maximum log level with [`max_level()`] and [`set_max_level`].
+ *
+ * [`Level`]: enum.Level.html
+ * [`max_level()`]: fn.max_level.html
+ * [`set_max_level`]: fn.set_max_level.html
+ */
+enum class LevelFilter : uintptr_t {
+    /**
+     * A level lower than all log levels.
+     */
+    LevelFilter_Off,
+    /**
+     * Corresponds to the `Error` log level.
+     */
+    LevelFilter_Error,
+    /**
+     * Corresponds to the `Warn` log level.
+     */
+    LevelFilter_Warn,
+    /**
+     * Corresponds to the `Info` log level.
+     */
+    LevelFilter_Info,
+    /**
+     * Corresponds to the `Debug` log level.
+     */
+    LevelFilter_Debug,
+    /**
+     * Corresponds to the `Trace` log level.
+     */
+    LevelFilter_Trace,
+};
+
 struct ArchitectureObj;
 
 
@@ -63,7 +141,7 @@ struct DeferedForget {
 
 /** Workaround for void types in generic functions. */
 struct StoreAll {
-    constexpr auto operator[](StoreAll) const {
+    constexpr bool operator[](StoreAll) const {
         return false;
     }
 
@@ -73,7 +151,7 @@ struct StoreAll {
     }
 
     template <class T>
-    constexpr friend T && operator,(T &&t, StoreAll) {
+    friend T && operator,(T &&t, StoreAll) {
         return std::forward<T>(t);
     }
 };
@@ -139,12 +217,9 @@ template<typename CGlueCtx = void>
 using KeyboardStateRetTmp = void;
 
 template<typename T = void>
-using MaybeUninit = T;
-
-template<typename T>
 struct alignas(alignof(T)) RustMaybeUninit {
     char pad[sizeof(T)];
-    constexpr T &assume_init() {
+    inline T &assume_init() {
         return *(T *)this;
     }
     constexpr const T &assume_init() const {
@@ -346,7 +421,7 @@ struct ConnectorInstanceContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline auto clone_context() noexcept {
+    inline Context clone_context() noexcept {
         return context.clone();
     }
 
@@ -366,7 +441,7 @@ struct ConnectorInstanceContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline auto clone_context() noexcept {}
+    inline Context clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -499,7 +574,7 @@ using PhysicalReadData = MemData<PhysicalAddress, CSliceMut<uint8_t>>;
 template<typename T>
 struct CIterator {
     void *iter;
-    int32_t (*func)(void*, MaybeUninit<T> *out);
+    int32_t (*func)(void*, T *out);
 
     class iterator : std::iterator<std::input_iterator_tag, T> {
         CIterator<T> *iter;
@@ -533,7 +608,7 @@ struct CIterator {
             return !(*this == other);
         }
 
-        constexpr T &operator*() {
+        inline T &operator*() {
             return data.assume_init();
         }
 
@@ -559,7 +634,7 @@ struct CPPIterator {
     CIterator<T> iter;
     typename Container::iterator cur, end;
 
-    static int32_t next(void *data, MaybeUninit<T> *out) {
+    static int32_t next(void *data, T *out) {
         CPPIterator *i = (CPPIterator *)data;
 
         if (i->cur == i->end) {
@@ -739,7 +814,7 @@ struct CGlueObjContainer {
     C context;
     RustMaybeUninit<R> ret_tmp;
 
-    inline auto clone_context() noexcept {
+    inline Context clone_context() noexcept {
         return context.clone();
     }
 
@@ -760,7 +835,7 @@ struct CGlueObjContainer<T, void, R> {
     T instance;
     RustMaybeUninit<R> ret_tmp;
 
-    inline auto clone_context() noexcept {}
+    inline Context clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -777,7 +852,7 @@ struct CGlueObjContainer<T, C, void> {
     T instance;
     C context;
 
-    inline auto clone_context() noexcept {
+    inline Context clone_context() noexcept {
         return context.clone();
     }
 
@@ -797,7 +872,7 @@ struct CGlueObjContainer<T, void, void> {
     typedef void Context;
     T instance;
 
-    auto clone_context() noexcept {}
+    inline Context clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -943,7 +1018,7 @@ struct IntoCpuStateContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline auto clone_context() noexcept {
+    inline Context clone_context() noexcept {
         return context.clone();
     }
 
@@ -963,7 +1038,7 @@ struct IntoCpuStateContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline auto clone_context() noexcept {}
+    inline Context clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1014,12 +1089,12 @@ struct IntoCpuState {
         return __ret;
     }
 
-    inline auto pause() noexcept {
+    inline void pause() noexcept {
     (this->vtbl_cpustate)->pause(&this->container);
 
     }
 
-    inline auto resume() noexcept {
+    inline void resume() noexcept {
     (this->vtbl_cpustate)->resume(&this->container);
 
     }
@@ -1034,8 +1109,8 @@ struct IntoCpuState {
 template<typename CGlueC>
 struct ConnectorCpuStateInnerVtbl {
     typedef typename CGlueC::Context Context;
-    int32_t (*cpu_state)(CGlueC *cont, MaybeUninit<CpuStateBase<CBox<void>, Context>> *ok_out);
-    int32_t (*into_cpu_state)(CGlueC cont, MaybeUninit<IntoCpuState<CBox<void>, Context>> *ok_out);
+    int32_t (*cpu_state)(CGlueC *cont, CpuStateBase<CBox<void>, Context> *ok_out);
+    int32_t (*into_cpu_state)(CGlueC cont, IntoCpuState<CBox<void>, Context> *ok_out);
 };
 
 template<typename Impl>
@@ -1089,44 +1164,44 @@ struct ConnectorInstance {
         return __ret;
     }
 
-    inline auto phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
+    inline int32_t phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_physicalmemory)->phys_read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
+    inline int32_t phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_physicalmemory)->phys_write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto metadata() const noexcept {
+    inline PhysicalMemoryMetadata metadata() const noexcept {
         PhysicalMemoryMetadata __ret = (this->vtbl_physicalmemory)->metadata(&this->container);
         return __ret;
     }
 
-    inline auto set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
+    inline void set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
     (this->vtbl_physicalmemory)->set_mem_map(&this->container, _mem_map);
 
     }
 
-    inline auto into_phys_view() && noexcept {
+    inline MemoryViewBase<CBox<void>, Context> into_phys_view() && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl_physicalmemory)->into_phys_view(this->container);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto phys_view() noexcept {
+    inline MemoryViewBase<CBox<void>, Context> phys_view() noexcept {
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl_physicalmemory)->phys_view(&this->container);
         return __ret;
     }
 
-    inline auto cpu_state(MaybeUninit<CpuStateBase<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t cpu_state(CpuStateBase<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_connectorcpustateinner)->cpu_state(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto into_cpu_state(MaybeUninit<IntoCpuState<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_cpu_state(IntoCpuState<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_connectorcpustateinner)->into_cpu_state(this->container, ok_out);
         mem_forget(this->container);
@@ -1146,7 +1221,7 @@ using ConnectorInstanceBase = ConnectorInstanceBaseArcBox<CGlueT,CGlueArcTy>;
 
 using ConnectorInstanceArcBox = ConnectorInstanceBaseArcBox<void, void>;
 
-using MuConnectorInstanceArcBox = MaybeUninit<ConnectorInstanceArcBox>;
+using MuConnectorInstanceArcBox = ConnectorInstanceArcBox;
 // Typedef for default contaienr and context type
 using MuConnectorInstance = MuConnectorInstanceArcBox;
 
@@ -1156,7 +1231,7 @@ struct OsInstanceContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline auto clone_context() noexcept {
+    inline Context clone_context() noexcept {
         return context.clone();
     }
 
@@ -1176,7 +1251,7 @@ struct OsInstanceContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline auto clone_context() noexcept {}
+    inline Context clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1341,7 +1416,7 @@ struct ProcessInstanceContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline auto clone_context() noexcept {
+    inline Context clone_context() noexcept {
         return context.clone();
     }
 
@@ -1361,7 +1436,7 @@ struct ProcessInstanceContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline auto clone_context() noexcept {}
+    inline Context clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1501,17 +1576,17 @@ struct ProcessVtbl {
     ProcessState (*state)(CGlueC *cont);
     int32_t (*module_address_list_callback)(CGlueC *cont, const ArchitectureIdent *target_arch, ModuleAddressCallback callback);
     int32_t (*module_list_callback)(CGlueC *cont, const ArchitectureIdent *target_arch, ModuleInfoCallback callback);
-    int32_t (*module_by_address)(CGlueC *cont, Address address, ArchitectureIdent architecture, MaybeUninit<ModuleInfo> *ok_out);
-    int32_t (*module_by_name_arch)(CGlueC *cont, CSliceRef<uint8_t> name, const ArchitectureIdent *architecture, MaybeUninit<ModuleInfo> *ok_out);
-    int32_t (*module_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> *ok_out);
-    int32_t (*primary_module_address)(CGlueC *cont, MaybeUninit<Address> *ok_out);
-    int32_t (*primary_module)(CGlueC *cont, MaybeUninit<ModuleInfo> *ok_out);
+    int32_t (*module_by_address)(CGlueC *cont, Address address, ArchitectureIdent architecture, ModuleInfo *ok_out);
+    int32_t (*module_by_name_arch)(CGlueC *cont, CSliceRef<uint8_t> name, const ArchitectureIdent *architecture, ModuleInfo *ok_out);
+    int32_t (*module_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, ModuleInfo *ok_out);
+    int32_t (*primary_module_address)(CGlueC *cont, Address *ok_out);
+    int32_t (*primary_module)(CGlueC *cont, ModuleInfo *ok_out);
     int32_t (*module_import_list_callback)(CGlueC *cont, const ModuleInfo *info, ImportCallback callback);
     int32_t (*module_export_list_callback)(CGlueC *cont, const ModuleInfo *info, ExportCallback callback);
     int32_t (*module_section_list_callback)(CGlueC *cont, const ModuleInfo *info, SectionCallback callback);
-    int32_t (*module_import_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, MaybeUninit<ImportInfo> *ok_out);
-    int32_t (*module_export_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, MaybeUninit<ExportInfo> *ok_out);
-    int32_t (*module_section_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, MaybeUninit<SectionInfo> *ok_out);
+    int32_t (*module_import_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, ImportInfo *ok_out);
+    int32_t (*module_export_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, ExportInfo *ok_out);
+    int32_t (*module_section_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, SectionInfo *ok_out);
     const ProcessInfo *(*info)(const CGlueC *cont);
 };
 
@@ -1622,8 +1697,8 @@ struct VirtualTranslateVtbl {
     void (*virt_to_phys_range)(CGlueC *cont, Address start, Address end, VirtualTranslationCallback out);
     void (*virt_translation_map_range)(CGlueC *cont, Address start, Address end, VirtualTranslationCallback out);
     void (*virt_page_map_range)(CGlueC *cont, umem gap_size, Address start, Address end, MemoryRangeCallback out);
-    int32_t (*virt_to_phys)(CGlueC *cont, Address address, MaybeUninit<PhysicalAddress> *ok_out);
-    int32_t (*virt_page_info)(CGlueC *cont, Address addr, MaybeUninit<Page> *ok_out);
+    int32_t (*virt_to_phys)(CGlueC *cont, Address address, PhysicalAddress *ok_out);
+    int32_t (*virt_page_info)(CGlueC *cont, Address addr, Page *ok_out);
     void (*virt_translation_map)(CGlueC *cont, VirtualTranslationCallback out);
     COption<Address> (*phys_to_virt)(CGlueC *cont, Address phys);
     void (*virt_page_map)(CGlueC *cont, umem gap_size, MemoryRangeCallback out);
@@ -1678,157 +1753,157 @@ struct ProcessInstance {
 
     typedef CGlueCtx Context;
 
-    inline auto read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
+    inline int32_t read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
+    inline int32_t write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto metadata() const noexcept {
+    inline MemoryViewMetadata metadata() const noexcept {
         MemoryViewMetadata __ret = (this->vtbl_memoryview)->metadata(&this->container);
         return __ret;
     }
 
-    inline auto read_raw_list(CSliceMut<ReadData> data) noexcept {
+    inline int32_t read_raw_list(CSliceMut<ReadData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline auto read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
+    inline int32_t read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_into(&this->container, addr, out);
         return __ret;
     }
 
-    inline auto write_raw_list(CSliceRef<WriteData> data) noexcept {
+    inline int32_t write_raw_list(CSliceRef<WriteData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline auto write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
+    inline int32_t write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw(&this->container, addr, data);
         return __ret;
     }
 
-    inline auto state() noexcept {
+    inline ProcessState state() noexcept {
         ProcessState __ret = (this->vtbl_process)->state(&this->container);
         return __ret;
     }
 
-    inline auto module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
+    inline int32_t module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_address_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline auto module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
+    inline int32_t module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline auto module_by_address(Address address, ArchitectureIdent architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_address(Address address, ArchitectureIdent architecture, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_address(&this->container, address, architecture, ok_out);
         return __ret;
     }
 
-    inline auto module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_name_arch(&this->container, name, architecture, ok_out);
         return __ret;
     }
 
-    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto primary_module_address(MaybeUninit<Address> * ok_out) noexcept {
+    inline int32_t primary_module_address(Address * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->primary_module_address(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto primary_module(MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t primary_module(ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->primary_module(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
+    inline int32_t module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_import_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
+    inline int32_t module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_export_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
+    inline int32_t module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_section_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ImportInfo> * ok_out) noexcept {
+    inline int32_t module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ImportInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_import_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ExportInfo> * ok_out) noexcept {
+    inline int32_t module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ExportInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_export_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<SectionInfo> * ok_out) noexcept {
+    inline int32_t module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, SectionInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_section_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto info() const noexcept {
+    inline const ProcessInfo * info() const noexcept {
         const ProcessInfo * __ret = (this->vtbl_process)->info(&this->container);
         return __ret;
     }
 
-    inline auto virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
+    inline void virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
     (this->vtbl_virtualtranslate)->virt_to_phys_list(&this->container, addrs, out, out_fail);
 
     }
 
-    inline auto virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline void virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_to_phys_range(&this->container, start, end, out);
 
     }
 
-    inline auto virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline void virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_translation_map_range(&this->container, start, end, out);
 
     }
 
-    inline auto virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
+    inline void virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_page_map_range(&this->container, gap_size, start, end, out);
 
     }
 
-    inline auto virt_to_phys(Address address, MaybeUninit<PhysicalAddress> * ok_out) noexcept {
+    inline int32_t virt_to_phys(Address address, PhysicalAddress * ok_out) noexcept {
         int32_t __ret = (this->vtbl_virtualtranslate)->virt_to_phys(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline auto virt_page_info(Address addr, MaybeUninit<Page> * ok_out) noexcept {
+    inline int32_t virt_page_info(Address addr, Page * ok_out) noexcept {
         int32_t __ret = (this->vtbl_virtualtranslate)->virt_page_info(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline auto virt_translation_map(VirtualTranslationCallback out) noexcept {
+    inline void virt_translation_map(VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_translation_map(&this->container, out);
 
     }
 
-    inline auto phys_to_virt(Address phys) noexcept {
+    inline COption<Address> phys_to_virt(Address phys) noexcept {
         COption<Address> __ret = (this->vtbl_virtualtranslate)->phys_to_virt(&this->container, phys);
         return __ret;
     }
 
-    inline auto virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
+    inline void virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_page_map(&this->container, gap_size, out);
 
     }
@@ -1841,7 +1916,7 @@ struct IntoProcessInstanceContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline auto clone_context() noexcept {
+    inline Context clone_context() noexcept {
         return context.clone();
     }
 
@@ -1861,7 +1936,7 @@ struct IntoProcessInstanceContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline auto clone_context() noexcept {}
+    inline Context clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1916,157 +1991,157 @@ struct IntoProcessInstance {
         return __ret;
     }
 
-    inline auto read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
+    inline int32_t read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
+    inline int32_t write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto metadata() const noexcept {
+    inline MemoryViewMetadata metadata() const noexcept {
         MemoryViewMetadata __ret = (this->vtbl_memoryview)->metadata(&this->container);
         return __ret;
     }
 
-    inline auto read_raw_list(CSliceMut<ReadData> data) noexcept {
+    inline int32_t read_raw_list(CSliceMut<ReadData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline auto read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
+    inline int32_t read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_into(&this->container, addr, out);
         return __ret;
     }
 
-    inline auto write_raw_list(CSliceRef<WriteData> data) noexcept {
+    inline int32_t write_raw_list(CSliceRef<WriteData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline auto write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
+    inline int32_t write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw(&this->container, addr, data);
         return __ret;
     }
 
-    inline auto state() noexcept {
+    inline ProcessState state() noexcept {
         ProcessState __ret = (this->vtbl_process)->state(&this->container);
         return __ret;
     }
 
-    inline auto module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
+    inline int32_t module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_address_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline auto module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
+    inline int32_t module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline auto module_by_address(Address address, ArchitectureIdent architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_address(Address address, ArchitectureIdent architecture, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_address(&this->container, address, architecture, ok_out);
         return __ret;
     }
 
-    inline auto module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_name_arch(&this->container, name, architecture, ok_out);
         return __ret;
     }
 
-    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto primary_module_address(MaybeUninit<Address> * ok_out) noexcept {
+    inline int32_t primary_module_address(Address * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->primary_module_address(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto primary_module(MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t primary_module(ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->primary_module(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
+    inline int32_t module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_import_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
+    inline int32_t module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_export_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
+    inline int32_t module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_section_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ImportInfo> * ok_out) noexcept {
+    inline int32_t module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ImportInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_import_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ExportInfo> * ok_out) noexcept {
+    inline int32_t module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ExportInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_export_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<SectionInfo> * ok_out) noexcept {
+    inline int32_t module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, SectionInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_section_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto info() const noexcept {
+    inline const ProcessInfo * info() const noexcept {
         const ProcessInfo * __ret = (this->vtbl_process)->info(&this->container);
         return __ret;
     }
 
-    inline auto virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
+    inline void virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
     (this->vtbl_virtualtranslate)->virt_to_phys_list(&this->container, addrs, out, out_fail);
 
     }
 
-    inline auto virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline void virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_to_phys_range(&this->container, start, end, out);
 
     }
 
-    inline auto virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline void virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_translation_map_range(&this->container, start, end, out);
 
     }
 
-    inline auto virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
+    inline void virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_page_map_range(&this->container, gap_size, start, end, out);
 
     }
 
-    inline auto virt_to_phys(Address address, MaybeUninit<PhysicalAddress> * ok_out) noexcept {
+    inline int32_t virt_to_phys(Address address, PhysicalAddress * ok_out) noexcept {
         int32_t __ret = (this->vtbl_virtualtranslate)->virt_to_phys(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline auto virt_page_info(Address addr, MaybeUninit<Page> * ok_out) noexcept {
+    inline int32_t virt_page_info(Address addr, Page * ok_out) noexcept {
         int32_t __ret = (this->vtbl_virtualtranslate)->virt_page_info(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline auto virt_translation_map(VirtualTranslationCallback out) noexcept {
+    inline void virt_translation_map(VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_translation_map(&this->container, out);
 
     }
 
-    inline auto phys_to_virt(Address phys) noexcept {
+    inline COption<Address> phys_to_virt(Address phys) noexcept {
         COption<Address> __ret = (this->vtbl_virtualtranslate)->phys_to_virt(&this->container, phys);
         return __ret;
     }
 
-    inline auto virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
+    inline void virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_page_map(&this->container, gap_size, out);
 
     }
@@ -2105,21 +2180,21 @@ struct OsInnerVtbl {
     typedef typename CGlueC::Context Context;
     int32_t (*process_address_list_callback)(CGlueC *cont, AddressCallback callback);
     int32_t (*process_info_list_callback)(CGlueC *cont, ProcessInfoCallback callback);
-    int32_t (*process_info_by_address)(CGlueC *cont, Address address, MaybeUninit<ProcessInfo> *ok_out);
-    int32_t (*process_info_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, MaybeUninit<ProcessInfo> *ok_out);
-    int32_t (*process_info_by_pid)(CGlueC *cont, Pid pid, MaybeUninit<ProcessInfo> *ok_out);
-    int32_t (*process_by_info)(CGlueC *cont, ProcessInfo info, MaybeUninit<ProcessInstance<CBox<void>, Context>> *ok_out);
-    int32_t (*into_process_by_info)(CGlueC cont, ProcessInfo info, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> *ok_out);
-    int32_t (*process_by_address)(CGlueC *cont, Address addr, MaybeUninit<ProcessInstance<CBox<void>, Context>> *ok_out);
-    int32_t (*process_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, MaybeUninit<ProcessInstance<CBox<void>, Context>> *ok_out);
-    int32_t (*process_by_pid)(CGlueC *cont, Pid pid, MaybeUninit<ProcessInstance<CBox<void>, Context>> *ok_out);
-    int32_t (*into_process_by_address)(CGlueC cont, Address addr, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> *ok_out);
-    int32_t (*into_process_by_name)(CGlueC cont, CSliceRef<uint8_t> name, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> *ok_out);
-    int32_t (*into_process_by_pid)(CGlueC cont, Pid pid, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> *ok_out);
+    int32_t (*process_info_by_address)(CGlueC *cont, Address address, ProcessInfo *ok_out);
+    int32_t (*process_info_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, ProcessInfo *ok_out);
+    int32_t (*process_info_by_pid)(CGlueC *cont, Pid pid, ProcessInfo *ok_out);
+    int32_t (*process_by_info)(CGlueC *cont, ProcessInfo info, ProcessInstance<CBox<void>, Context> *ok_out);
+    int32_t (*into_process_by_info)(CGlueC cont, ProcessInfo info, IntoProcessInstance<CBox<void>, Context> *ok_out);
+    int32_t (*process_by_address)(CGlueC *cont, Address addr, ProcessInstance<CBox<void>, Context> *ok_out);
+    int32_t (*process_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, ProcessInstance<CBox<void>, Context> *ok_out);
+    int32_t (*process_by_pid)(CGlueC *cont, Pid pid, ProcessInstance<CBox<void>, Context> *ok_out);
+    int32_t (*into_process_by_address)(CGlueC cont, Address addr, IntoProcessInstance<CBox<void>, Context> *ok_out);
+    int32_t (*into_process_by_name)(CGlueC cont, CSliceRef<uint8_t> name, IntoProcessInstance<CBox<void>, Context> *ok_out);
+    int32_t (*into_process_by_pid)(CGlueC cont, Pid pid, IntoProcessInstance<CBox<void>, Context> *ok_out);
     int32_t (*module_address_list_callback)(CGlueC *cont, AddressCallback callback);
     int32_t (*module_list_callback)(CGlueC *cont, ModuleInfoCallback callback);
-    int32_t (*module_by_address)(CGlueC *cont, Address address, MaybeUninit<ModuleInfo> *ok_out);
-    int32_t (*module_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> *ok_out);
+    int32_t (*module_by_address)(CGlueC *cont, Address address, ModuleInfo *ok_out);
+    int32_t (*module_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, ModuleInfo *ok_out);
     const OsInfo *(*info)(const CGlueC *cont);
 };
 
@@ -2183,7 +2258,7 @@ struct KeyboardVtbl {
     typedef typename CGlueC::Context Context;
     bool (*is_down)(CGlueC *cont, int32_t vk);
     void (*set_down)(CGlueC *cont, int32_t vk, bool down);
-    int32_t (*state)(CGlueC *cont, MaybeUninit<KeyboardStateBase<CBox<void>, Context>> *ok_out);
+    int32_t (*state)(CGlueC *cont, KeyboardStateBase<CBox<void>, Context> *ok_out);
 };
 
 template<typename Impl>
@@ -2208,7 +2283,7 @@ struct IntoKeyboardContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline auto clone_context() noexcept {
+    inline Context clone_context() noexcept {
         return context.clone();
     }
 
@@ -2228,7 +2303,7 @@ struct IntoKeyboardContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline auto clone_context() noexcept {}
+    inline Context clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -2279,17 +2354,17 @@ struct IntoKeyboard {
         return __ret;
     }
 
-    inline auto is_down(int32_t vk) noexcept {
+    inline bool is_down(int32_t vk) noexcept {
         bool __ret = (this->vtbl_keyboard)->is_down(&this->container, vk);
         return __ret;
     }
 
-    inline auto set_down(int32_t vk, bool down) noexcept {
+    inline void set_down(int32_t vk, bool down) noexcept {
     (this->vtbl_keyboard)->set_down(&this->container, vk, down);
 
     }
 
-    inline auto state(MaybeUninit<KeyboardStateBase<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t state(KeyboardStateBase<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_keyboard)->state(&this->container, ok_out);
         return __ret;
     }
@@ -2304,8 +2379,8 @@ struct IntoKeyboard {
 template<typename CGlueC>
 struct OsKeyboardInnerVtbl {
     typedef typename CGlueC::Context Context;
-    int32_t (*keyboard)(CGlueC *cont, MaybeUninit<KeyboardBase<CBox<void>, Context>> *ok_out);
-    int32_t (*into_keyboard)(CGlueC cont, MaybeUninit<IntoKeyboard<CBox<void>, Context>> *ok_out);
+    int32_t (*keyboard)(CGlueC *cont, KeyboardBase<CBox<void>, Context> *ok_out);
+    int32_t (*into_keyboard)(CGlueC cont, IntoKeyboard<CBox<void>, Context> *ok_out);
 };
 
 template<typename Impl>
@@ -2363,179 +2438,179 @@ struct OsInstance {
         return __ret;
     }
 
-    inline auto process_address_list_callback(AddressCallback callback) noexcept {
+    inline int32_t process_address_list_callback(AddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_address_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline auto process_info_list_callback(ProcessInfoCallback callback) noexcept {
+    inline int32_t process_info_list_callback(ProcessInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_info_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline auto process_info_by_address(Address address, MaybeUninit<ProcessInfo> * ok_out) noexcept {
+    inline int32_t process_info_by_address(Address address, ProcessInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_info_by_address(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline auto process_info_by_name(CSliceRef<uint8_t> name, MaybeUninit<ProcessInfo> * ok_out) noexcept {
+    inline int32_t process_info_by_name(CSliceRef<uint8_t> name, ProcessInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_info_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto process_info_by_pid(Pid pid, MaybeUninit<ProcessInfo> * ok_out) noexcept {
+    inline int32_t process_info_by_pid(Pid pid, ProcessInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_info_by_pid(&this->container, pid, ok_out);
         return __ret;
     }
 
-    inline auto process_by_info(ProcessInfo info, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t process_by_info(ProcessInfo info, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_by_info(&this->container, info, ok_out);
         return __ret;
     }
 
-    inline auto into_process_by_info(ProcessInfo info, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_process_by_info(ProcessInfo info, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_osinner)->into_process_by_info(this->container, info, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto process_by_address(Address addr, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t process_by_address(Address addr, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_by_address(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline auto process_by_name(CSliceRef<uint8_t> name, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t process_by_name(CSliceRef<uint8_t> name, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto process_by_pid(Pid pid, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t process_by_pid(Pid pid, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_by_pid(&this->container, pid, ok_out);
         return __ret;
     }
 
-    inline auto into_process_by_address(Address addr, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_process_by_address(Address addr, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_osinner)->into_process_by_address(this->container, addr, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto into_process_by_name(CSliceRef<uint8_t> name, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_process_by_name(CSliceRef<uint8_t> name, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_osinner)->into_process_by_name(this->container, name, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto into_process_by_pid(Pid pid, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_process_by_pid(Pid pid, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_osinner)->into_process_by_pid(this->container, pid, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto module_address_list_callback(AddressCallback callback) noexcept {
+    inline int32_t module_address_list_callback(AddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl_osinner)->module_address_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline auto module_list_callback(ModuleInfoCallback callback) noexcept {
+    inline int32_t module_list_callback(ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl_osinner)->module_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline auto module_by_address(Address address, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_address(Address address, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->module_by_address(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto info() const noexcept {
+    inline const OsInfo * info() const noexcept {
         const OsInfo * __ret = (this->vtbl_osinner)->info(&this->container);
         return __ret;
     }
 
-    inline auto read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
+    inline int32_t read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
+    inline int32_t write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto memoryview_metadata() const noexcept {
+    inline MemoryViewMetadata memoryview_metadata() const noexcept {
         MemoryViewMetadata __ret = (this->vtbl_memoryview)->metadata(&this->container);
         return __ret;
     }
 
-    inline auto read_raw_list(CSliceMut<ReadData> data) noexcept {
+    inline int32_t read_raw_list(CSliceMut<ReadData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline auto read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
+    inline int32_t read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_into(&this->container, addr, out);
         return __ret;
     }
 
-    inline auto write_raw_list(CSliceRef<WriteData> data) noexcept {
+    inline int32_t write_raw_list(CSliceRef<WriteData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline auto write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
+    inline int32_t write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw(&this->container, addr, data);
         return __ret;
     }
 
-    inline auto keyboard(MaybeUninit<KeyboardBase<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t keyboard(KeyboardBase<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_oskeyboardinner)->keyboard(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto into_keyboard(MaybeUninit<IntoKeyboard<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_keyboard(IntoKeyboard<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_oskeyboardinner)->into_keyboard(this->container, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
+    inline int32_t phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_physicalmemory)->phys_read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
+    inline int32_t phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_physicalmemory)->phys_write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto physicalmemory_metadata() const noexcept {
+    inline PhysicalMemoryMetadata physicalmemory_metadata() const noexcept {
         PhysicalMemoryMetadata __ret = (this->vtbl_physicalmemory)->metadata(&this->container);
         return __ret;
     }
 
-    inline auto set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
+    inline void set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
     (this->vtbl_physicalmemory)->set_mem_map(&this->container, _mem_map);
 
     }
 
-    inline auto into_phys_view() && noexcept {
+    inline MemoryViewBase<CBox<void>, Context> into_phys_view() && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl_physicalmemory)->into_phys_view(this->container);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto phys_view() noexcept {
+    inline MemoryViewBase<CBox<void>, Context> phys_view() noexcept {
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl_physicalmemory)->phys_view(&this->container);
         return __ret;
     }
@@ -2553,7 +2628,7 @@ using OsInstanceBase = OsInstanceBaseArcBox<CGlueT,CGlueArcTy>;
 
 using OsInstanceArcBox = OsInstanceBaseArcBox<void, void>;
 
-using MuOsInstanceArcBox = MaybeUninit<OsInstanceArcBox>;
+using MuOsInstanceArcBox = OsInstanceArcBox;
 // Typedef for default contaienr and context type
 using MuOsInstance = MuOsInstanceArcBox;
 
@@ -2606,9 +2681,29 @@ extern const ArchitectureObj *X86_32_PAE;
 
 extern const ArchitectureObj *X86_64;
 
-void log_init(int32_t level_num);
+/**
+ * Initialize logging with selected logging level.
+ */
+void log_init(LevelFilter level_filter);
 
+/**
+ * Logs an error with custom log level.
+ */
+void log_error(Level level, int32_t error);
+
+/**
+ * Logs an error with debug log level.
+ */
 void debug_error(int32_t error);
+
+/**
+ * Sets new maximum log level.
+ *
+ * If `inventory` is supplied, the log level is also updated within all plugin instances. However,
+ * if it is not supplied, plugins will not have their log levels updated, potentially leading to
+ * lower performance, or less logging than expected.
+ */
+void set_max_level(LevelFilter level_filter, const Inventory *inventory);
 
 /**
  * Helper to convert `Address` to a `PhysicalAddress`
@@ -2812,37 +2907,37 @@ struct CGlueTraitObj<T, MemoryViewVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline auto read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
+    inline int32_t read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl)->read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
+    inline int32_t write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl)->write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto metadata() const noexcept {
+    inline MemoryViewMetadata metadata() const noexcept {
         MemoryViewMetadata __ret = (this->vtbl)->metadata(&this->container);
         return __ret;
     }
 
-    inline auto read_raw_list(CSliceMut<ReadData> data) noexcept {
+    inline int32_t read_raw_list(CSliceMut<ReadData> data) noexcept {
         int32_t __ret = (this->vtbl)->read_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline auto read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
+    inline int32_t read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
         int32_t __ret = (this->vtbl)->read_raw_into(&this->container, addr, out);
         return __ret;
     }
 
-    inline auto write_raw_list(CSliceRef<WriteData> data) noexcept {
+    inline int32_t write_raw_list(CSliceRef<WriteData> data) noexcept {
         int32_t __ret = (this->vtbl)->write_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline auto write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
+    inline int32_t write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
         int32_t __ret = (this->vtbl)->write_raw(&this->container, addr, data);
         return __ret;
     }
@@ -2862,34 +2957,34 @@ struct CGlueTraitObj<T, PhysicalMemoryVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline auto phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
+    inline int32_t phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl)->phys_read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
+    inline int32_t phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl)->phys_write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline auto metadata() const noexcept {
+    inline PhysicalMemoryMetadata metadata() const noexcept {
         PhysicalMemoryMetadata __ret = (this->vtbl)->metadata(&this->container);
         return __ret;
     }
 
-    inline auto set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
+    inline void set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
     (this->vtbl)->set_mem_map(&this->container, _mem_map);
 
     }
 
-    inline auto into_phys_view() && noexcept {
+    inline MemoryViewBase<CBox<void>, Context> into_phys_view() && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl)->into_phys_view(this->container);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto phys_view() noexcept {
+    inline MemoryViewBase<CBox<void>, Context> phys_view() noexcept {
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl)->phys_view(&this->container);
         return __ret;
     }
@@ -2909,12 +3004,12 @@ struct CGlueTraitObj<T, CpuStateVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline auto pause() noexcept {
+    inline void pause() noexcept {
     (this->vtbl)->pause(&this->container);
 
     }
 
-    inline auto resume() noexcept {
+    inline void resume() noexcept {
     (this->vtbl)->resume(&this->container);
 
     }
@@ -2934,12 +3029,12 @@ struct CGlueTraitObj<T, ConnectorCpuStateInnerVtbl<CGlueObjContainer<T, C, R>>, 
 
     typedef C Context;
 
-    inline auto cpu_state(MaybeUninit<CpuStateBase<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t cpu_state(CpuStateBase<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->cpu_state(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto into_cpu_state(MaybeUninit<IntoCpuState<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_cpu_state(IntoCpuState<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_cpu_state(this->container, ok_out);
         mem_forget(this->container);
@@ -2961,77 +3056,77 @@ struct CGlueTraitObj<T, ProcessVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline auto state() noexcept {
+    inline ProcessState state() noexcept {
         ProcessState __ret = (this->vtbl)->state(&this->container);
         return __ret;
     }
 
-    inline auto module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
+    inline int32_t module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_address_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline auto module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
+    inline int32_t module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline auto module_by_address(Address address, ArchitectureIdent architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_address(Address address, ArchitectureIdent architecture, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_address(&this->container, address, architecture, ok_out);
         return __ret;
     }
 
-    inline auto module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_name_arch(&this->container, name, architecture, ok_out);
         return __ret;
     }
 
-    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto primary_module_address(MaybeUninit<Address> * ok_out) noexcept {
+    inline int32_t primary_module_address(Address * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->primary_module_address(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto primary_module(MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t primary_module(ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->primary_module(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
+    inline int32_t module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_import_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
+    inline int32_t module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_export_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
+    inline int32_t module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_section_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline auto module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ImportInfo> * ok_out) noexcept {
+    inline int32_t module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ImportInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_import_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ExportInfo> * ok_out) noexcept {
+    inline int32_t module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ExportInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_export_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<SectionInfo> * ok_out) noexcept {
+    inline int32_t module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, SectionInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_section_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline auto info() const noexcept {
+    inline const ProcessInfo * info() const noexcept {
         const ProcessInfo * __ret = (this->vtbl)->info(&this->container);
         return __ret;
     }
@@ -3051,47 +3146,47 @@ struct CGlueTraitObj<T, VirtualTranslateVtbl<CGlueObjContainer<T, C, R>>, C, R> 
 
     typedef C Context;
 
-    inline auto virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
+    inline void virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
     (this->vtbl)->virt_to_phys_list(&this->container, addrs, out, out_fail);
 
     }
 
-    inline auto virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline void virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl)->virt_to_phys_range(&this->container, start, end, out);
 
     }
 
-    inline auto virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline void virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl)->virt_translation_map_range(&this->container, start, end, out);
 
     }
 
-    inline auto virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
+    inline void virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
     (this->vtbl)->virt_page_map_range(&this->container, gap_size, start, end, out);
 
     }
 
-    inline auto virt_to_phys(Address address, MaybeUninit<PhysicalAddress> * ok_out) noexcept {
+    inline int32_t virt_to_phys(Address address, PhysicalAddress * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->virt_to_phys(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline auto virt_page_info(Address addr, MaybeUninit<Page> * ok_out) noexcept {
+    inline int32_t virt_page_info(Address addr, Page * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->virt_page_info(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline auto virt_translation_map(VirtualTranslationCallback out) noexcept {
+    inline void virt_translation_map(VirtualTranslationCallback out) noexcept {
     (this->vtbl)->virt_translation_map(&this->container, out);
 
     }
 
-    inline auto phys_to_virt(Address phys) noexcept {
+    inline COption<Address> phys_to_virt(Address phys) noexcept {
         COption<Address> __ret = (this->vtbl)->phys_to_virt(&this->container, phys);
         return __ret;
     }
 
-    inline auto virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
+    inline void virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
     (this->vtbl)->virt_page_map(&this->container, gap_size, out);
 
     }
@@ -3111,100 +3206,100 @@ struct CGlueTraitObj<T, OsInnerVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline auto process_address_list_callback(AddressCallback callback) noexcept {
+    inline int32_t process_address_list_callback(AddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->process_address_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline auto process_info_list_callback(ProcessInfoCallback callback) noexcept {
+    inline int32_t process_info_list_callback(ProcessInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->process_info_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline auto process_info_by_address(Address address, MaybeUninit<ProcessInfo> * ok_out) noexcept {
+    inline int32_t process_info_by_address(Address address, ProcessInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_info_by_address(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline auto process_info_by_name(CSliceRef<uint8_t> name, MaybeUninit<ProcessInfo> * ok_out) noexcept {
+    inline int32_t process_info_by_name(CSliceRef<uint8_t> name, ProcessInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_info_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto process_info_by_pid(Pid pid, MaybeUninit<ProcessInfo> * ok_out) noexcept {
+    inline int32_t process_info_by_pid(Pid pid, ProcessInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_info_by_pid(&this->container, pid, ok_out);
         return __ret;
     }
 
-    inline auto process_by_info(ProcessInfo info, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t process_by_info(ProcessInfo info, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_by_info(&this->container, info, ok_out);
         return __ret;
     }
 
-    inline auto into_process_by_info(ProcessInfo info, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_process_by_info(ProcessInfo info, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_process_by_info(this->container, info, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto process_by_address(Address addr, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t process_by_address(Address addr, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_by_address(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline auto process_by_name(CSliceRef<uint8_t> name, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t process_by_name(CSliceRef<uint8_t> name, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto process_by_pid(Pid pid, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t process_by_pid(Pid pid, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_by_pid(&this->container, pid, ok_out);
         return __ret;
     }
 
-    inline auto into_process_by_address(Address addr, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_process_by_address(Address addr, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_process_by_address(this->container, addr, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto into_process_by_name(CSliceRef<uint8_t> name, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_process_by_name(CSliceRef<uint8_t> name, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_process_by_name(this->container, name, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto into_process_by_pid(Pid pid, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_process_by_pid(Pid pid, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_process_by_pid(this->container, pid, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline auto module_address_list_callback(AddressCallback callback) noexcept {
+    inline int32_t module_address_list_callback(AddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_address_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline auto module_list_callback(ModuleInfoCallback callback) noexcept {
+    inline int32_t module_list_callback(ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline auto module_by_address(Address address, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_address(Address address, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_address(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
+    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline auto info() const noexcept {
+    inline const OsInfo * info() const noexcept {
         const OsInfo * __ret = (this->vtbl)->info(&this->container);
         return __ret;
     }
@@ -3224,7 +3319,7 @@ struct CGlueTraitObj<T, KeyboardStateVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline auto is_down(int32_t vk) const noexcept {
+    inline bool is_down(int32_t vk) const noexcept {
         bool __ret = (this->vtbl)->is_down(&this->container, vk);
         return __ret;
     }
@@ -3244,17 +3339,17 @@ struct CGlueTraitObj<T, KeyboardVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline auto is_down(int32_t vk) noexcept {
+    inline bool is_down(int32_t vk) noexcept {
         bool __ret = (this->vtbl)->is_down(&this->container, vk);
         return __ret;
     }
 
-    inline auto set_down(int32_t vk, bool down) noexcept {
+    inline void set_down(int32_t vk, bool down) noexcept {
     (this->vtbl)->set_down(&this->container, vk, down);
 
     }
 
-    inline auto state(MaybeUninit<KeyboardStateBase<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t state(KeyboardStateBase<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->state(&this->container, ok_out);
         return __ret;
     }
@@ -3274,12 +3369,12 @@ struct CGlueTraitObj<T, OsKeyboardInnerVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline auto keyboard(MaybeUninit<KeyboardBase<CBox<void>, Context>> * ok_out) noexcept {
+    inline int32_t keyboard(KeyboardBase<CBox<void>, Context> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->keyboard(&this->container, ok_out);
         return __ret;
     }
 
-    inline auto into_keyboard(MaybeUninit<IntoKeyboard<CBox<void>, Context>> * ok_out) && noexcept {
+    inline int32_t into_keyboard(IntoKeyboard<CBox<void>, Context> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_keyboard(this->container, ok_out);
         mem_forget(this->container);

--- a/memflow-ffi/memflow.hpp
+++ b/memflow-ffi/memflow.hpp
@@ -141,7 +141,7 @@ struct DeferedForget {
 
 /** Workaround for void types in generic functions. */
 struct StoreAll {
-    constexpr bool operator[](StoreAll) const {
+    constexpr auto operator[](StoreAll) const {
         return false;
     }
 
@@ -151,7 +151,7 @@ struct StoreAll {
     }
 
     template <class T>
-    friend T && operator,(T &&t, StoreAll) {
+    constexpr friend T && operator,(T &&t, StoreAll) {
         return std::forward<T>(t);
     }
 };
@@ -217,9 +217,12 @@ template<typename CGlueCtx = void>
 using KeyboardStateRetTmp = void;
 
 template<typename T = void>
+using MaybeUninit = T;
+
+template<typename T>
 struct alignas(alignof(T)) RustMaybeUninit {
     char pad[sizeof(T)];
-    inline T &assume_init() {
+    constexpr T &assume_init() {
         return *(T *)this;
     }
     constexpr const T &assume_init() const {
@@ -421,7 +424,7 @@ struct ConnectorInstanceContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline Context clone_context() noexcept {
+    inline auto clone_context() noexcept {
         return context.clone();
     }
 
@@ -441,7 +444,7 @@ struct ConnectorInstanceContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline Context clone_context() noexcept {}
+    inline auto clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -574,7 +577,7 @@ using PhysicalReadData = MemData<PhysicalAddress, CSliceMut<uint8_t>>;
 template<typename T>
 struct CIterator {
     void *iter;
-    int32_t (*func)(void*, T *out);
+    int32_t (*func)(void*, MaybeUninit<T> *out);
 
     class iterator : std::iterator<std::input_iterator_tag, T> {
         CIterator<T> *iter;
@@ -608,7 +611,7 @@ struct CIterator {
             return !(*this == other);
         }
 
-        inline T &operator*() {
+        constexpr T &operator*() {
             return data.assume_init();
         }
 
@@ -634,7 +637,7 @@ struct CPPIterator {
     CIterator<T> iter;
     typename Container::iterator cur, end;
 
-    static int32_t next(void *data, T *out) {
+    static int32_t next(void *data, MaybeUninit<T> *out) {
         CPPIterator *i = (CPPIterator *)data;
 
         if (i->cur == i->end) {
@@ -814,7 +817,7 @@ struct CGlueObjContainer {
     C context;
     RustMaybeUninit<R> ret_tmp;
 
-    inline Context clone_context() noexcept {
+    inline auto clone_context() noexcept {
         return context.clone();
     }
 
@@ -835,7 +838,7 @@ struct CGlueObjContainer<T, void, R> {
     T instance;
     RustMaybeUninit<R> ret_tmp;
 
-    inline Context clone_context() noexcept {}
+    inline auto clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -852,7 +855,7 @@ struct CGlueObjContainer<T, C, void> {
     T instance;
     C context;
 
-    inline Context clone_context() noexcept {
+    inline auto clone_context() noexcept {
         return context.clone();
     }
 
@@ -872,7 +875,7 @@ struct CGlueObjContainer<T, void, void> {
     typedef void Context;
     T instance;
 
-    inline Context clone_context() noexcept {}
+    auto clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1018,7 +1021,7 @@ struct IntoCpuStateContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline Context clone_context() noexcept {
+    inline auto clone_context() noexcept {
         return context.clone();
     }
 
@@ -1038,7 +1041,7 @@ struct IntoCpuStateContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline Context clone_context() noexcept {}
+    inline auto clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1089,12 +1092,12 @@ struct IntoCpuState {
         return __ret;
     }
 
-    inline void pause() noexcept {
+    inline auto pause() noexcept {
     (this->vtbl_cpustate)->pause(&this->container);
 
     }
 
-    inline void resume() noexcept {
+    inline auto resume() noexcept {
     (this->vtbl_cpustate)->resume(&this->container);
 
     }
@@ -1109,8 +1112,8 @@ struct IntoCpuState {
 template<typename CGlueC>
 struct ConnectorCpuStateInnerVtbl {
     typedef typename CGlueC::Context Context;
-    int32_t (*cpu_state)(CGlueC *cont, CpuStateBase<CBox<void>, Context> *ok_out);
-    int32_t (*into_cpu_state)(CGlueC cont, IntoCpuState<CBox<void>, Context> *ok_out);
+    int32_t (*cpu_state)(CGlueC *cont, MaybeUninit<CpuStateBase<CBox<void>, Context>> *ok_out);
+    int32_t (*into_cpu_state)(CGlueC cont, MaybeUninit<IntoCpuState<CBox<void>, Context>> *ok_out);
 };
 
 template<typename Impl>
@@ -1164,44 +1167,44 @@ struct ConnectorInstance {
         return __ret;
     }
 
-    inline int32_t phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
+    inline auto phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_physicalmemory)->phys_read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline int32_t phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
+    inline auto phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_physicalmemory)->phys_write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline PhysicalMemoryMetadata metadata() const noexcept {
+    inline auto metadata() const noexcept {
         PhysicalMemoryMetadata __ret = (this->vtbl_physicalmemory)->metadata(&this->container);
         return __ret;
     }
 
-    inline void set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
+    inline auto set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
     (this->vtbl_physicalmemory)->set_mem_map(&this->container, _mem_map);
 
     }
 
-    inline MemoryViewBase<CBox<void>, Context> into_phys_view() && noexcept {
+    inline auto into_phys_view() && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl_physicalmemory)->into_phys_view(this->container);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline MemoryViewBase<CBox<void>, Context> phys_view() noexcept {
+    inline auto phys_view() noexcept {
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl_physicalmemory)->phys_view(&this->container);
         return __ret;
     }
 
-    inline int32_t cpu_state(CpuStateBase<CBox<void>, Context> * ok_out) noexcept {
+    inline auto cpu_state(MaybeUninit<CpuStateBase<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_connectorcpustateinner)->cpu_state(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t into_cpu_state(IntoCpuState<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_cpu_state(MaybeUninit<IntoCpuState<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_connectorcpustateinner)->into_cpu_state(this->container, ok_out);
         mem_forget(this->container);
@@ -1221,7 +1224,7 @@ using ConnectorInstanceBase = ConnectorInstanceBaseArcBox<CGlueT,CGlueArcTy>;
 
 using ConnectorInstanceArcBox = ConnectorInstanceBaseArcBox<void, void>;
 
-using MuConnectorInstanceArcBox = ConnectorInstanceArcBox;
+using MuConnectorInstanceArcBox = MaybeUninit<ConnectorInstanceArcBox>;
 // Typedef for default contaienr and context type
 using MuConnectorInstance = MuConnectorInstanceArcBox;
 
@@ -1231,7 +1234,7 @@ struct OsInstanceContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline Context clone_context() noexcept {
+    inline auto clone_context() noexcept {
         return context.clone();
     }
 
@@ -1251,7 +1254,7 @@ struct OsInstanceContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline Context clone_context() noexcept {}
+    inline auto clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1416,7 +1419,7 @@ struct ProcessInstanceContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline Context clone_context() noexcept {
+    inline auto clone_context() noexcept {
         return context.clone();
     }
 
@@ -1436,7 +1439,7 @@ struct ProcessInstanceContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline Context clone_context() noexcept {}
+    inline auto clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1576,17 +1579,17 @@ struct ProcessVtbl {
     ProcessState (*state)(CGlueC *cont);
     int32_t (*module_address_list_callback)(CGlueC *cont, const ArchitectureIdent *target_arch, ModuleAddressCallback callback);
     int32_t (*module_list_callback)(CGlueC *cont, const ArchitectureIdent *target_arch, ModuleInfoCallback callback);
-    int32_t (*module_by_address)(CGlueC *cont, Address address, ArchitectureIdent architecture, ModuleInfo *ok_out);
-    int32_t (*module_by_name_arch)(CGlueC *cont, CSliceRef<uint8_t> name, const ArchitectureIdent *architecture, ModuleInfo *ok_out);
-    int32_t (*module_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, ModuleInfo *ok_out);
-    int32_t (*primary_module_address)(CGlueC *cont, Address *ok_out);
-    int32_t (*primary_module)(CGlueC *cont, ModuleInfo *ok_out);
+    int32_t (*module_by_address)(CGlueC *cont, Address address, ArchitectureIdent architecture, MaybeUninit<ModuleInfo> *ok_out);
+    int32_t (*module_by_name_arch)(CGlueC *cont, CSliceRef<uint8_t> name, const ArchitectureIdent *architecture, MaybeUninit<ModuleInfo> *ok_out);
+    int32_t (*module_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> *ok_out);
+    int32_t (*primary_module_address)(CGlueC *cont, MaybeUninit<Address> *ok_out);
+    int32_t (*primary_module)(CGlueC *cont, MaybeUninit<ModuleInfo> *ok_out);
     int32_t (*module_import_list_callback)(CGlueC *cont, const ModuleInfo *info, ImportCallback callback);
     int32_t (*module_export_list_callback)(CGlueC *cont, const ModuleInfo *info, ExportCallback callback);
     int32_t (*module_section_list_callback)(CGlueC *cont, const ModuleInfo *info, SectionCallback callback);
-    int32_t (*module_import_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, ImportInfo *ok_out);
-    int32_t (*module_export_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, ExportInfo *ok_out);
-    int32_t (*module_section_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, SectionInfo *ok_out);
+    int32_t (*module_import_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, MaybeUninit<ImportInfo> *ok_out);
+    int32_t (*module_export_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, MaybeUninit<ExportInfo> *ok_out);
+    int32_t (*module_section_by_name)(CGlueC *cont, const ModuleInfo *info, CSliceRef<uint8_t> name, MaybeUninit<SectionInfo> *ok_out);
     const ProcessInfo *(*info)(const CGlueC *cont);
 };
 
@@ -1697,8 +1700,8 @@ struct VirtualTranslateVtbl {
     void (*virt_to_phys_range)(CGlueC *cont, Address start, Address end, VirtualTranslationCallback out);
     void (*virt_translation_map_range)(CGlueC *cont, Address start, Address end, VirtualTranslationCallback out);
     void (*virt_page_map_range)(CGlueC *cont, umem gap_size, Address start, Address end, MemoryRangeCallback out);
-    int32_t (*virt_to_phys)(CGlueC *cont, Address address, PhysicalAddress *ok_out);
-    int32_t (*virt_page_info)(CGlueC *cont, Address addr, Page *ok_out);
+    int32_t (*virt_to_phys)(CGlueC *cont, Address address, MaybeUninit<PhysicalAddress> *ok_out);
+    int32_t (*virt_page_info)(CGlueC *cont, Address addr, MaybeUninit<Page> *ok_out);
     void (*virt_translation_map)(CGlueC *cont, VirtualTranslationCallback out);
     COption<Address> (*phys_to_virt)(CGlueC *cont, Address phys);
     void (*virt_page_map)(CGlueC *cont, umem gap_size, MemoryRangeCallback out);
@@ -1753,157 +1756,157 @@ struct ProcessInstance {
 
     typedef CGlueCtx Context;
 
-    inline int32_t read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
+    inline auto read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline int32_t write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
+    inline auto write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline MemoryViewMetadata metadata() const noexcept {
+    inline auto metadata() const noexcept {
         MemoryViewMetadata __ret = (this->vtbl_memoryview)->metadata(&this->container);
         return __ret;
     }
 
-    inline int32_t read_raw_list(CSliceMut<ReadData> data) noexcept {
+    inline auto read_raw_list(CSliceMut<ReadData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline int32_t read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
+    inline auto read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_into(&this->container, addr, out);
         return __ret;
     }
 
-    inline int32_t write_raw_list(CSliceRef<WriteData> data) noexcept {
+    inline auto write_raw_list(CSliceRef<WriteData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline int32_t write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
+    inline auto write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw(&this->container, addr, data);
         return __ret;
     }
 
-    inline ProcessState state() noexcept {
+    inline auto state() noexcept {
         ProcessState __ret = (this->vtbl_process)->state(&this->container);
         return __ret;
     }
 
-    inline int32_t module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
+    inline auto module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_address_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline int32_t module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
+    inline auto module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline int32_t module_by_address(Address address, ArchitectureIdent architecture, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_address(Address address, ArchitectureIdent architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_address(&this->container, address, architecture, ok_out);
         return __ret;
     }
 
-    inline int32_t module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_name_arch(&this->container, name, architecture, ok_out);
         return __ret;
     }
 
-    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline int32_t primary_module_address(Address * ok_out) noexcept {
+    inline auto primary_module_address(MaybeUninit<Address> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->primary_module_address(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t primary_module(ModuleInfo * ok_out) noexcept {
+    inline auto primary_module(MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->primary_module(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
+    inline auto module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_import_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
+    inline auto module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_export_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
+    inline auto module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_section_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ImportInfo * ok_out) noexcept {
+    inline auto module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ImportInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_import_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline int32_t module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ExportInfo * ok_out) noexcept {
+    inline auto module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ExportInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_export_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline int32_t module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, SectionInfo * ok_out) noexcept {
+    inline auto module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<SectionInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_section_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline const ProcessInfo * info() const noexcept {
+    inline auto info() const noexcept {
         const ProcessInfo * __ret = (this->vtbl_process)->info(&this->container);
         return __ret;
     }
 
-    inline void virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
+    inline auto virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
     (this->vtbl_virtualtranslate)->virt_to_phys_list(&this->container, addrs, out, out_fail);
 
     }
 
-    inline void virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline auto virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_to_phys_range(&this->container, start, end, out);
 
     }
 
-    inline void virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline auto virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_translation_map_range(&this->container, start, end, out);
 
     }
 
-    inline void virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
+    inline auto virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_page_map_range(&this->container, gap_size, start, end, out);
 
     }
 
-    inline int32_t virt_to_phys(Address address, PhysicalAddress * ok_out) noexcept {
+    inline auto virt_to_phys(Address address, MaybeUninit<PhysicalAddress> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_virtualtranslate)->virt_to_phys(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline int32_t virt_page_info(Address addr, Page * ok_out) noexcept {
+    inline auto virt_page_info(Address addr, MaybeUninit<Page> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_virtualtranslate)->virt_page_info(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline void virt_translation_map(VirtualTranslationCallback out) noexcept {
+    inline auto virt_translation_map(VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_translation_map(&this->container, out);
 
     }
 
-    inline COption<Address> phys_to_virt(Address phys) noexcept {
+    inline auto phys_to_virt(Address phys) noexcept {
         COption<Address> __ret = (this->vtbl_virtualtranslate)->phys_to_virt(&this->container, phys);
         return __ret;
     }
 
-    inline void virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
+    inline auto virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_page_map(&this->container, gap_size, out);
 
     }
@@ -1916,7 +1919,7 @@ struct IntoProcessInstanceContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline Context clone_context() noexcept {
+    inline auto clone_context() noexcept {
         return context.clone();
     }
 
@@ -1936,7 +1939,7 @@ struct IntoProcessInstanceContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline Context clone_context() noexcept {}
+    inline auto clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -1991,157 +1994,157 @@ struct IntoProcessInstance {
         return __ret;
     }
 
-    inline int32_t read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
+    inline auto read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline int32_t write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
+    inline auto write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline MemoryViewMetadata metadata() const noexcept {
+    inline auto metadata() const noexcept {
         MemoryViewMetadata __ret = (this->vtbl_memoryview)->metadata(&this->container);
         return __ret;
     }
 
-    inline int32_t read_raw_list(CSliceMut<ReadData> data) noexcept {
+    inline auto read_raw_list(CSliceMut<ReadData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline int32_t read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
+    inline auto read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_into(&this->container, addr, out);
         return __ret;
     }
 
-    inline int32_t write_raw_list(CSliceRef<WriteData> data) noexcept {
+    inline auto write_raw_list(CSliceRef<WriteData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline int32_t write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
+    inline auto write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw(&this->container, addr, data);
         return __ret;
     }
 
-    inline ProcessState state() noexcept {
+    inline auto state() noexcept {
         ProcessState __ret = (this->vtbl_process)->state(&this->container);
         return __ret;
     }
 
-    inline int32_t module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
+    inline auto module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_address_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline int32_t module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
+    inline auto module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline int32_t module_by_address(Address address, ArchitectureIdent architecture, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_address(Address address, ArchitectureIdent architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_address(&this->container, address, architecture, ok_out);
         return __ret;
     }
 
-    inline int32_t module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_name_arch(&this->container, name, architecture, ok_out);
         return __ret;
     }
 
-    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline int32_t primary_module_address(Address * ok_out) noexcept {
+    inline auto primary_module_address(MaybeUninit<Address> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->primary_module_address(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t primary_module(ModuleInfo * ok_out) noexcept {
+    inline auto primary_module(MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->primary_module(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
+    inline auto module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_import_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
+    inline auto module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_export_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
+    inline auto module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
         int32_t __ret = (this->vtbl_process)->module_section_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ImportInfo * ok_out) noexcept {
+    inline auto module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ImportInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_import_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline int32_t module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ExportInfo * ok_out) noexcept {
+    inline auto module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ExportInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_export_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline int32_t module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, SectionInfo * ok_out) noexcept {
+    inline auto module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<SectionInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_process)->module_section_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline const ProcessInfo * info() const noexcept {
+    inline auto info() const noexcept {
         const ProcessInfo * __ret = (this->vtbl_process)->info(&this->container);
         return __ret;
     }
 
-    inline void virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
+    inline auto virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
     (this->vtbl_virtualtranslate)->virt_to_phys_list(&this->container, addrs, out, out_fail);
 
     }
 
-    inline void virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline auto virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_to_phys_range(&this->container, start, end, out);
 
     }
 
-    inline void virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline auto virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_translation_map_range(&this->container, start, end, out);
 
     }
 
-    inline void virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
+    inline auto virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_page_map_range(&this->container, gap_size, start, end, out);
 
     }
 
-    inline int32_t virt_to_phys(Address address, PhysicalAddress * ok_out) noexcept {
+    inline auto virt_to_phys(Address address, MaybeUninit<PhysicalAddress> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_virtualtranslate)->virt_to_phys(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline int32_t virt_page_info(Address addr, Page * ok_out) noexcept {
+    inline auto virt_page_info(Address addr, MaybeUninit<Page> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_virtualtranslate)->virt_page_info(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline void virt_translation_map(VirtualTranslationCallback out) noexcept {
+    inline auto virt_translation_map(VirtualTranslationCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_translation_map(&this->container, out);
 
     }
 
-    inline COption<Address> phys_to_virt(Address phys) noexcept {
+    inline auto phys_to_virt(Address phys) noexcept {
         COption<Address> __ret = (this->vtbl_virtualtranslate)->phys_to_virt(&this->container, phys);
         return __ret;
     }
 
-    inline void virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
+    inline auto virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
     (this->vtbl_virtualtranslate)->virt_page_map(&this->container, gap_size, out);
 
     }
@@ -2180,21 +2183,21 @@ struct OsInnerVtbl {
     typedef typename CGlueC::Context Context;
     int32_t (*process_address_list_callback)(CGlueC *cont, AddressCallback callback);
     int32_t (*process_info_list_callback)(CGlueC *cont, ProcessInfoCallback callback);
-    int32_t (*process_info_by_address)(CGlueC *cont, Address address, ProcessInfo *ok_out);
-    int32_t (*process_info_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, ProcessInfo *ok_out);
-    int32_t (*process_info_by_pid)(CGlueC *cont, Pid pid, ProcessInfo *ok_out);
-    int32_t (*process_by_info)(CGlueC *cont, ProcessInfo info, ProcessInstance<CBox<void>, Context> *ok_out);
-    int32_t (*into_process_by_info)(CGlueC cont, ProcessInfo info, IntoProcessInstance<CBox<void>, Context> *ok_out);
-    int32_t (*process_by_address)(CGlueC *cont, Address addr, ProcessInstance<CBox<void>, Context> *ok_out);
-    int32_t (*process_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, ProcessInstance<CBox<void>, Context> *ok_out);
-    int32_t (*process_by_pid)(CGlueC *cont, Pid pid, ProcessInstance<CBox<void>, Context> *ok_out);
-    int32_t (*into_process_by_address)(CGlueC cont, Address addr, IntoProcessInstance<CBox<void>, Context> *ok_out);
-    int32_t (*into_process_by_name)(CGlueC cont, CSliceRef<uint8_t> name, IntoProcessInstance<CBox<void>, Context> *ok_out);
-    int32_t (*into_process_by_pid)(CGlueC cont, Pid pid, IntoProcessInstance<CBox<void>, Context> *ok_out);
+    int32_t (*process_info_by_address)(CGlueC *cont, Address address, MaybeUninit<ProcessInfo> *ok_out);
+    int32_t (*process_info_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, MaybeUninit<ProcessInfo> *ok_out);
+    int32_t (*process_info_by_pid)(CGlueC *cont, Pid pid, MaybeUninit<ProcessInfo> *ok_out);
+    int32_t (*process_by_info)(CGlueC *cont, ProcessInfo info, MaybeUninit<ProcessInstance<CBox<void>, Context>> *ok_out);
+    int32_t (*into_process_by_info)(CGlueC cont, ProcessInfo info, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> *ok_out);
+    int32_t (*process_by_address)(CGlueC *cont, Address addr, MaybeUninit<ProcessInstance<CBox<void>, Context>> *ok_out);
+    int32_t (*process_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, MaybeUninit<ProcessInstance<CBox<void>, Context>> *ok_out);
+    int32_t (*process_by_pid)(CGlueC *cont, Pid pid, MaybeUninit<ProcessInstance<CBox<void>, Context>> *ok_out);
+    int32_t (*into_process_by_address)(CGlueC cont, Address addr, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> *ok_out);
+    int32_t (*into_process_by_name)(CGlueC cont, CSliceRef<uint8_t> name, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> *ok_out);
+    int32_t (*into_process_by_pid)(CGlueC cont, Pid pid, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> *ok_out);
     int32_t (*module_address_list_callback)(CGlueC *cont, AddressCallback callback);
     int32_t (*module_list_callback)(CGlueC *cont, ModuleInfoCallback callback);
-    int32_t (*module_by_address)(CGlueC *cont, Address address, ModuleInfo *ok_out);
-    int32_t (*module_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, ModuleInfo *ok_out);
+    int32_t (*module_by_address)(CGlueC *cont, Address address, MaybeUninit<ModuleInfo> *ok_out);
+    int32_t (*module_by_name)(CGlueC *cont, CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> *ok_out);
     const OsInfo *(*info)(const CGlueC *cont);
 };
 
@@ -2258,7 +2261,7 @@ struct KeyboardVtbl {
     typedef typename CGlueC::Context Context;
     bool (*is_down)(CGlueC *cont, int32_t vk);
     void (*set_down)(CGlueC *cont, int32_t vk, bool down);
-    int32_t (*state)(CGlueC *cont, KeyboardStateBase<CBox<void>, Context> *ok_out);
+    int32_t (*state)(CGlueC *cont, MaybeUninit<KeyboardStateBase<CBox<void>, Context>> *ok_out);
 };
 
 template<typename Impl>
@@ -2283,7 +2286,7 @@ struct IntoKeyboardContainer {
     CGlueInst instance;
     CGlueCtx context;
 
-    inline Context clone_context() noexcept {
+    inline auto clone_context() noexcept {
         return context.clone();
     }
 
@@ -2303,7 +2306,7 @@ struct IntoKeyboardContainer<CGlueInst, void> {
     typedef void Context;
     CGlueInst instance;
 
-    inline Context clone_context() noexcept {}
+    inline auto clone_context() noexcept {}
 
     inline void drop() && noexcept {
         mem_drop(std::move(instance));
@@ -2354,17 +2357,17 @@ struct IntoKeyboard {
         return __ret;
     }
 
-    inline bool is_down(int32_t vk) noexcept {
+    inline auto is_down(int32_t vk) noexcept {
         bool __ret = (this->vtbl_keyboard)->is_down(&this->container, vk);
         return __ret;
     }
 
-    inline void set_down(int32_t vk, bool down) noexcept {
+    inline auto set_down(int32_t vk, bool down) noexcept {
     (this->vtbl_keyboard)->set_down(&this->container, vk, down);
 
     }
 
-    inline int32_t state(KeyboardStateBase<CBox<void>, Context> * ok_out) noexcept {
+    inline auto state(MaybeUninit<KeyboardStateBase<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_keyboard)->state(&this->container, ok_out);
         return __ret;
     }
@@ -2379,8 +2382,8 @@ struct IntoKeyboard {
 template<typename CGlueC>
 struct OsKeyboardInnerVtbl {
     typedef typename CGlueC::Context Context;
-    int32_t (*keyboard)(CGlueC *cont, KeyboardBase<CBox<void>, Context> *ok_out);
-    int32_t (*into_keyboard)(CGlueC cont, IntoKeyboard<CBox<void>, Context> *ok_out);
+    int32_t (*keyboard)(CGlueC *cont, MaybeUninit<KeyboardBase<CBox<void>, Context>> *ok_out);
+    int32_t (*into_keyboard)(CGlueC cont, MaybeUninit<IntoKeyboard<CBox<void>, Context>> *ok_out);
 };
 
 template<typename Impl>
@@ -2438,179 +2441,179 @@ struct OsInstance {
         return __ret;
     }
 
-    inline int32_t process_address_list_callback(AddressCallback callback) noexcept {
+    inline auto process_address_list_callback(AddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_address_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline int32_t process_info_list_callback(ProcessInfoCallback callback) noexcept {
+    inline auto process_info_list_callback(ProcessInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_info_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline int32_t process_info_by_address(Address address, ProcessInfo * ok_out) noexcept {
+    inline auto process_info_by_address(Address address, MaybeUninit<ProcessInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_info_by_address(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline int32_t process_info_by_name(CSliceRef<uint8_t> name, ProcessInfo * ok_out) noexcept {
+    inline auto process_info_by_name(CSliceRef<uint8_t> name, MaybeUninit<ProcessInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_info_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline int32_t process_info_by_pid(Pid pid, ProcessInfo * ok_out) noexcept {
+    inline auto process_info_by_pid(Pid pid, MaybeUninit<ProcessInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_info_by_pid(&this->container, pid, ok_out);
         return __ret;
     }
 
-    inline int32_t process_by_info(ProcessInfo info, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
+    inline auto process_by_info(ProcessInfo info, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_by_info(&this->container, info, ok_out);
         return __ret;
     }
 
-    inline int32_t into_process_by_info(ProcessInfo info, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_process_by_info(ProcessInfo info, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_osinner)->into_process_by_info(this->container, info, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t process_by_address(Address addr, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
+    inline auto process_by_address(Address addr, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_by_address(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline int32_t process_by_name(CSliceRef<uint8_t> name, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
+    inline auto process_by_name(CSliceRef<uint8_t> name, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline int32_t process_by_pid(Pid pid, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
+    inline auto process_by_pid(Pid pid, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->process_by_pid(&this->container, pid, ok_out);
         return __ret;
     }
 
-    inline int32_t into_process_by_address(Address addr, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_process_by_address(Address addr, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_osinner)->into_process_by_address(this->container, addr, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t into_process_by_name(CSliceRef<uint8_t> name, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_process_by_name(CSliceRef<uint8_t> name, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_osinner)->into_process_by_name(this->container, name, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t into_process_by_pid(Pid pid, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_process_by_pid(Pid pid, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_osinner)->into_process_by_pid(this->container, pid, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t module_address_list_callback(AddressCallback callback) noexcept {
+    inline auto module_address_list_callback(AddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl_osinner)->module_address_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline int32_t module_list_callback(ModuleInfoCallback callback) noexcept {
+    inline auto module_list_callback(ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl_osinner)->module_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline int32_t module_by_address(Address address, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_address(Address address, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->module_by_address(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_osinner)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline const OsInfo * info() const noexcept {
+    inline auto info() const noexcept {
         const OsInfo * __ret = (this->vtbl_osinner)->info(&this->container);
         return __ret;
     }
 
-    inline int32_t read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
+    inline auto read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline int32_t write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
+    inline auto write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline MemoryViewMetadata memoryview_metadata() const noexcept {
+    inline auto memoryview_metadata() const noexcept {
         MemoryViewMetadata __ret = (this->vtbl_memoryview)->metadata(&this->container);
         return __ret;
     }
 
-    inline int32_t read_raw_list(CSliceMut<ReadData> data) noexcept {
+    inline auto read_raw_list(CSliceMut<ReadData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline int32_t read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
+    inline auto read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->read_raw_into(&this->container, addr, out);
         return __ret;
     }
 
-    inline int32_t write_raw_list(CSliceRef<WriteData> data) noexcept {
+    inline auto write_raw_list(CSliceRef<WriteData> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline int32_t write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
+    inline auto write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
         int32_t __ret = (this->vtbl_memoryview)->write_raw(&this->container, addr, data);
         return __ret;
     }
 
-    inline int32_t keyboard(KeyboardBase<CBox<void>, Context> * ok_out) noexcept {
+    inline auto keyboard(MaybeUninit<KeyboardBase<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl_oskeyboardinner)->keyboard(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t into_keyboard(IntoKeyboard<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_keyboard(MaybeUninit<IntoKeyboard<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl_oskeyboardinner)->into_keyboard(this->container, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
+    inline auto phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_physicalmemory)->phys_read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline int32_t phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
+    inline auto phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl_physicalmemory)->phys_write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline PhysicalMemoryMetadata physicalmemory_metadata() const noexcept {
+    inline auto physicalmemory_metadata() const noexcept {
         PhysicalMemoryMetadata __ret = (this->vtbl_physicalmemory)->metadata(&this->container);
         return __ret;
     }
 
-    inline void set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
+    inline auto set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
     (this->vtbl_physicalmemory)->set_mem_map(&this->container, _mem_map);
 
     }
 
-    inline MemoryViewBase<CBox<void>, Context> into_phys_view() && noexcept {
+    inline auto into_phys_view() && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl_physicalmemory)->into_phys_view(this->container);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline MemoryViewBase<CBox<void>, Context> phys_view() noexcept {
+    inline auto phys_view() noexcept {
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl_physicalmemory)->phys_view(&this->container);
         return __ret;
     }
@@ -2628,7 +2631,7 @@ using OsInstanceBase = OsInstanceBaseArcBox<CGlueT,CGlueArcTy>;
 
 using OsInstanceArcBox = OsInstanceBaseArcBox<void, void>;
 
-using MuOsInstanceArcBox = OsInstanceArcBox;
+using MuOsInstanceArcBox = MaybeUninit<OsInstanceArcBox>;
 // Typedef for default contaienr and context type
 using MuOsInstance = MuOsInstanceArcBox;
 
@@ -2689,12 +2692,12 @@ void log_init(LevelFilter level_filter);
 /**
  * Logs an error with custom log level.
  */
-void log_error(Level level, int32_t error);
+void log(Level level, int32_t error);
 
 /**
  * Logs an error with debug log level.
  */
-void debug_error(int32_t error);
+void log_debug_error(int32_t error);
 
 /**
  * Sets new maximum log level.
@@ -2703,7 +2706,7 @@ void debug_error(int32_t error);
  * if it is not supplied, plugins will not have their log levels updated, potentially leading to
  * lower performance, or less logging than expected.
  */
-void set_max_level(LevelFilter level_filter, const Inventory *inventory);
+void log_set_max_level(LevelFilter level_filter, const Inventory *inventory);
 
 /**
  * Helper to convert `Address` to a `PhysicalAddress`
@@ -2907,37 +2910,37 @@ struct CGlueTraitObj<T, MemoryViewVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline int32_t read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
+    inline auto read_raw_iter(CIterator<ReadData> data, ReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl)->read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline int32_t write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
+    inline auto write_raw_iter(CIterator<WriteData> data, WriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl)->write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline MemoryViewMetadata metadata() const noexcept {
+    inline auto metadata() const noexcept {
         MemoryViewMetadata __ret = (this->vtbl)->metadata(&this->container);
         return __ret;
     }
 
-    inline int32_t read_raw_list(CSliceMut<ReadData> data) noexcept {
+    inline auto read_raw_list(CSliceMut<ReadData> data) noexcept {
         int32_t __ret = (this->vtbl)->read_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline int32_t read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
+    inline auto read_raw_into(Address addr, CSliceMut<uint8_t> out) noexcept {
         int32_t __ret = (this->vtbl)->read_raw_into(&this->container, addr, out);
         return __ret;
     }
 
-    inline int32_t write_raw_list(CSliceRef<WriteData> data) noexcept {
+    inline auto write_raw_list(CSliceRef<WriteData> data) noexcept {
         int32_t __ret = (this->vtbl)->write_raw_list(&this->container, data);
         return __ret;
     }
 
-    inline int32_t write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
+    inline auto write_raw(Address addr, CSliceRef<uint8_t> data) noexcept {
         int32_t __ret = (this->vtbl)->write_raw(&this->container, addr, data);
         return __ret;
     }
@@ -2957,34 +2960,34 @@ struct CGlueTraitObj<T, PhysicalMemoryVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline int32_t phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
+    inline auto phys_read_raw_iter(CIterator<PhysicalReadData> data, PhysicalReadFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl)->phys_read_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline int32_t phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
+    inline auto phys_write_raw_iter(CIterator<PhysicalWriteData> data, PhysicalWriteFailCallback * out_fail) noexcept {
         int32_t __ret = (this->vtbl)->phys_write_raw_iter(&this->container, data, out_fail);
         return __ret;
     }
 
-    inline PhysicalMemoryMetadata metadata() const noexcept {
+    inline auto metadata() const noexcept {
         PhysicalMemoryMetadata __ret = (this->vtbl)->metadata(&this->container);
         return __ret;
     }
 
-    inline void set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
+    inline auto set_mem_map(CSliceRef<PhysicalMemoryMapping> _mem_map) noexcept {
     (this->vtbl)->set_mem_map(&this->container, _mem_map);
 
     }
 
-    inline MemoryViewBase<CBox<void>, Context> into_phys_view() && noexcept {
+    inline auto into_phys_view() && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl)->into_phys_view(this->container);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline MemoryViewBase<CBox<void>, Context> phys_view() noexcept {
+    inline auto phys_view() noexcept {
         MemoryViewBase<CBox<void>, Context> __ret = (this->vtbl)->phys_view(&this->container);
         return __ret;
     }
@@ -3004,12 +3007,12 @@ struct CGlueTraitObj<T, CpuStateVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline void pause() noexcept {
+    inline auto pause() noexcept {
     (this->vtbl)->pause(&this->container);
 
     }
 
-    inline void resume() noexcept {
+    inline auto resume() noexcept {
     (this->vtbl)->resume(&this->container);
 
     }
@@ -3029,12 +3032,12 @@ struct CGlueTraitObj<T, ConnectorCpuStateInnerVtbl<CGlueObjContainer<T, C, R>>, 
 
     typedef C Context;
 
-    inline int32_t cpu_state(CpuStateBase<CBox<void>, Context> * ok_out) noexcept {
+    inline auto cpu_state(MaybeUninit<CpuStateBase<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->cpu_state(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t into_cpu_state(IntoCpuState<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_cpu_state(MaybeUninit<IntoCpuState<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_cpu_state(this->container, ok_out);
         mem_forget(this->container);
@@ -3056,77 +3059,77 @@ struct CGlueTraitObj<T, ProcessVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline ProcessState state() noexcept {
+    inline auto state() noexcept {
         ProcessState __ret = (this->vtbl)->state(&this->container);
         return __ret;
     }
 
-    inline int32_t module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
+    inline auto module_address_list_callback(const ArchitectureIdent * target_arch, ModuleAddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_address_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline int32_t module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
+    inline auto module_list_callback(const ArchitectureIdent * target_arch, ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_list_callback(&this->container, target_arch, callback);
         return __ret;
     }
 
-    inline int32_t module_by_address(Address address, ArchitectureIdent architecture, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_address(Address address, ArchitectureIdent architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_address(&this->container, address, architecture, ok_out);
         return __ret;
     }
 
-    inline int32_t module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_name_arch(CSliceRef<uint8_t> name, const ArchitectureIdent * architecture, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_name_arch(&this->container, name, architecture, ok_out);
         return __ret;
     }
 
-    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline int32_t primary_module_address(Address * ok_out) noexcept {
+    inline auto primary_module_address(MaybeUninit<Address> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->primary_module_address(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t primary_module(ModuleInfo * ok_out) noexcept {
+    inline auto primary_module(MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->primary_module(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
+    inline auto module_import_list_callback(const ModuleInfo * info, ImportCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_import_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
+    inline auto module_export_list_callback(const ModuleInfo * info, ExportCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_export_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
+    inline auto module_section_list_callback(const ModuleInfo * info, SectionCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_section_list_callback(&this->container, info, callback);
         return __ret;
     }
 
-    inline int32_t module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ImportInfo * ok_out) noexcept {
+    inline auto module_import_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ImportInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_import_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline int32_t module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, ExportInfo * ok_out) noexcept {
+    inline auto module_export_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<ExportInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_export_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline int32_t module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, SectionInfo * ok_out) noexcept {
+    inline auto module_section_by_name(const ModuleInfo * info, CSliceRef<uint8_t> name, MaybeUninit<SectionInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_section_by_name(&this->container, info, name, ok_out);
         return __ret;
     }
 
-    inline const ProcessInfo * info() const noexcept {
+    inline auto info() const noexcept {
         const ProcessInfo * __ret = (this->vtbl)->info(&this->container);
         return __ret;
     }
@@ -3146,47 +3149,47 @@ struct CGlueTraitObj<T, VirtualTranslateVtbl<CGlueObjContainer<T, C, R>>, C, R> 
 
     typedef C Context;
 
-    inline void virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
+    inline auto virt_to_phys_list(CSliceRef<MemoryRange> addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail) noexcept {
     (this->vtbl)->virt_to_phys_list(&this->container, addrs, out, out_fail);
 
     }
 
-    inline void virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline auto virt_to_phys_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl)->virt_to_phys_range(&this->container, start, end, out);
 
     }
 
-    inline void virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
+    inline auto virt_translation_map_range(Address start, Address end, VirtualTranslationCallback out) noexcept {
     (this->vtbl)->virt_translation_map_range(&this->container, start, end, out);
 
     }
 
-    inline void virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
+    inline auto virt_page_map_range(umem gap_size, Address start, Address end, MemoryRangeCallback out) noexcept {
     (this->vtbl)->virt_page_map_range(&this->container, gap_size, start, end, out);
 
     }
 
-    inline int32_t virt_to_phys(Address address, PhysicalAddress * ok_out) noexcept {
+    inline auto virt_to_phys(Address address, MaybeUninit<PhysicalAddress> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->virt_to_phys(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline int32_t virt_page_info(Address addr, Page * ok_out) noexcept {
+    inline auto virt_page_info(Address addr, MaybeUninit<Page> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->virt_page_info(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline void virt_translation_map(VirtualTranslationCallback out) noexcept {
+    inline auto virt_translation_map(VirtualTranslationCallback out) noexcept {
     (this->vtbl)->virt_translation_map(&this->container, out);
 
     }
 
-    inline COption<Address> phys_to_virt(Address phys) noexcept {
+    inline auto phys_to_virt(Address phys) noexcept {
         COption<Address> __ret = (this->vtbl)->phys_to_virt(&this->container, phys);
         return __ret;
     }
 
-    inline void virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
+    inline auto virt_page_map(umem gap_size, MemoryRangeCallback out) noexcept {
     (this->vtbl)->virt_page_map(&this->container, gap_size, out);
 
     }
@@ -3206,100 +3209,100 @@ struct CGlueTraitObj<T, OsInnerVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline int32_t process_address_list_callback(AddressCallback callback) noexcept {
+    inline auto process_address_list_callback(AddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->process_address_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline int32_t process_info_list_callback(ProcessInfoCallback callback) noexcept {
+    inline auto process_info_list_callback(ProcessInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->process_info_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline int32_t process_info_by_address(Address address, ProcessInfo * ok_out) noexcept {
+    inline auto process_info_by_address(Address address, MaybeUninit<ProcessInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_info_by_address(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline int32_t process_info_by_name(CSliceRef<uint8_t> name, ProcessInfo * ok_out) noexcept {
+    inline auto process_info_by_name(CSliceRef<uint8_t> name, MaybeUninit<ProcessInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_info_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline int32_t process_info_by_pid(Pid pid, ProcessInfo * ok_out) noexcept {
+    inline auto process_info_by_pid(Pid pid, MaybeUninit<ProcessInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_info_by_pid(&this->container, pid, ok_out);
         return __ret;
     }
 
-    inline int32_t process_by_info(ProcessInfo info, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
+    inline auto process_by_info(ProcessInfo info, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_by_info(&this->container, info, ok_out);
         return __ret;
     }
 
-    inline int32_t into_process_by_info(ProcessInfo info, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_process_by_info(ProcessInfo info, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_process_by_info(this->container, info, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t process_by_address(Address addr, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
+    inline auto process_by_address(Address addr, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_by_address(&this->container, addr, ok_out);
         return __ret;
     }
 
-    inline int32_t process_by_name(CSliceRef<uint8_t> name, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
+    inline auto process_by_name(CSliceRef<uint8_t> name, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline int32_t process_by_pid(Pid pid, ProcessInstance<CBox<void>, Context> * ok_out) noexcept {
+    inline auto process_by_pid(Pid pid, MaybeUninit<ProcessInstance<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->process_by_pid(&this->container, pid, ok_out);
         return __ret;
     }
 
-    inline int32_t into_process_by_address(Address addr, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_process_by_address(Address addr, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_process_by_address(this->container, addr, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t into_process_by_name(CSliceRef<uint8_t> name, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_process_by_name(CSliceRef<uint8_t> name, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_process_by_name(this->container, name, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t into_process_by_pid(Pid pid, IntoProcessInstance<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_process_by_pid(Pid pid, MaybeUninit<IntoProcessInstance<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_process_by_pid(this->container, pid, ok_out);
         mem_forget(this->container);
         return __ret;
     }
 
-    inline int32_t module_address_list_callback(AddressCallback callback) noexcept {
+    inline auto module_address_list_callback(AddressCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_address_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline int32_t module_list_callback(ModuleInfoCallback callback) noexcept {
+    inline auto module_list_callback(ModuleInfoCallback callback) noexcept {
         int32_t __ret = (this->vtbl)->module_list_callback(&this->container, callback);
         return __ret;
     }
 
-    inline int32_t module_by_address(Address address, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_address(Address address, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_address(&this->container, address, ok_out);
         return __ret;
     }
 
-    inline int32_t module_by_name(CSliceRef<uint8_t> name, ModuleInfo * ok_out) noexcept {
+    inline auto module_by_name(CSliceRef<uint8_t> name, MaybeUninit<ModuleInfo> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->module_by_name(&this->container, name, ok_out);
         return __ret;
     }
 
-    inline const OsInfo * info() const noexcept {
+    inline auto info() const noexcept {
         const OsInfo * __ret = (this->vtbl)->info(&this->container);
         return __ret;
     }
@@ -3319,7 +3322,7 @@ struct CGlueTraitObj<T, KeyboardStateVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline bool is_down(int32_t vk) const noexcept {
+    inline auto is_down(int32_t vk) const noexcept {
         bool __ret = (this->vtbl)->is_down(&this->container, vk);
         return __ret;
     }
@@ -3339,17 +3342,17 @@ struct CGlueTraitObj<T, KeyboardVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline bool is_down(int32_t vk) noexcept {
+    inline auto is_down(int32_t vk) noexcept {
         bool __ret = (this->vtbl)->is_down(&this->container, vk);
         return __ret;
     }
 
-    inline void set_down(int32_t vk, bool down) noexcept {
+    inline auto set_down(int32_t vk, bool down) noexcept {
     (this->vtbl)->set_down(&this->container, vk, down);
 
     }
 
-    inline int32_t state(KeyboardStateBase<CBox<void>, Context> * ok_out) noexcept {
+    inline auto state(MaybeUninit<KeyboardStateBase<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->state(&this->container, ok_out);
         return __ret;
     }
@@ -3369,12 +3372,12 @@ struct CGlueTraitObj<T, OsKeyboardInnerVtbl<CGlueObjContainer<T, C, R>>, C, R> {
 
     typedef C Context;
 
-    inline int32_t keyboard(KeyboardBase<CBox<void>, Context> * ok_out) noexcept {
+    inline auto keyboard(MaybeUninit<KeyboardBase<CBox<void>, Context>> * ok_out) noexcept {
         int32_t __ret = (this->vtbl)->keyboard(&this->container, ok_out);
         return __ret;
     }
 
-    inline int32_t into_keyboard(IntoKeyboard<CBox<void>, Context> * ok_out) && noexcept {
+    inline auto into_keyboard(MaybeUninit<IntoKeyboard<CBox<void>, Context>> * ok_out) && noexcept {
         auto ___ctx = StoreAll()[this->container.clone_context(), StoreAll()];
         int32_t __ret = (this->vtbl)->into_keyboard(this->container, ok_out);
         mem_forget(this->container);

--- a/memflow-ffi/src/log.rs
+++ b/memflow-ffi/src/log.rs
@@ -1,27 +1,40 @@
-use log::{debug, Level};
+use log::{Level, LevelFilter};
 use memflow::cglue::IntError;
 use memflow::error::Error;
+use memflow::plugins::Inventory;
 use std::num::NonZeroI32;
 
+/// Initialize logging with selected logging level.
 #[no_mangle]
-pub extern "C" fn log_init(level_num: i32) {
-    let level = match level_num {
-        0 => Level::Error,
-        1 => Level::Warn,
-        2 => Level::Info,
-        3 => Level::Debug,
-        4 => Level::Trace,
-        _ => Level::Trace,
-    };
-    simple_logger::SimpleLogger::new()
-        .with_level(level.to_level_filter())
-        .init()
-        .unwrap();
+pub extern "C" fn log_init(level_filter: LevelFilter) {
+    simple_logger::SimpleLogger::new().init().unwrap();
+    log::set_max_level(level_filter);
 }
 
+/// Logs an error with custom log level.
+#[no_mangle]
+pub extern "C" fn log_error(level: Level, error: i32) {
+    if let Some(error) = NonZeroI32::new(error) {
+        log::log!(level, "{}", <Error as IntError>::from_int_err(error));
+    }
+}
+
+/// Logs an error with debug log level.
 #[no_mangle]
 pub extern "C" fn debug_error(error: i32) {
-    if let Some(error) = NonZeroI32::new(error) {
-        debug!("{}", <Error as IntError>::from_int_err(error));
+    log_error(Level::Debug, error)
+}
+
+/// Sets new maximum log level.
+///
+/// If `inventory` is supplied, the log level is also updated within all plugin instances. However,
+/// if it is not supplied, plugins will not have their log levels updated, potentially leading to
+/// lower performance, or less logging than expected.
+#[no_mangle]
+pub extern "C" fn set_max_level(level_filter: LevelFilter, inventory: Option<&Inventory>) {
+    log::set_max_level(level_filter);
+
+    if let Some(inventory) = inventory {
+        inventory.update_max_log_level();
     }
 }

--- a/memflow-ffi/src/log.rs
+++ b/memflow-ffi/src/log.rs
@@ -13,7 +13,7 @@ pub extern "C" fn log_init(level_filter: LevelFilter) {
 
 /// Logs an error with custom log level.
 #[no_mangle]
-pub extern "C" fn log_error(level: Level, error: i32) {
+pub extern "C" fn log(level: Level, error: i32) {
     if let Some(error) = NonZeroI32::new(error) {
         log::log!(level, "{}", <Error as IntError>::from_int_err(error));
     }
@@ -21,8 +21,8 @@ pub extern "C" fn log_error(level: Level, error: i32) {
 
 /// Logs an error with debug log level.
 #[no_mangle]
-pub extern "C" fn debug_error(error: i32) {
-    log_error(Level::Debug, error)
+pub extern "C" fn log_debug_error(error: i32) {
+    log(Level::Debug, error)
 }
 
 /// Sets new maximum log level.
@@ -31,10 +31,10 @@ pub extern "C" fn debug_error(error: i32) {
 /// if it is not supplied, plugins will not have their log levels updated, potentially leading to
 /// lower performance, or less logging than expected.
 #[no_mangle]
-pub extern "C" fn set_max_level(level_filter: LevelFilter, inventory: Option<&Inventory>) {
-    log::set_max_level(level_filter);
-
+pub extern "C" fn log_set_max_level(level_filter: LevelFilter, inventory: Option<&Inventory>) {
     if let Some(inventory) = inventory {
-        inventory.update_max_log_level();
+        inventory.set_max_log_level(level_filter);
+    } else {
+        log::set_max_level(level_filter);
     }
 }

--- a/memflow-win32/Cargo.toml
+++ b/memflow-win32/Cargo.toml
@@ -24,7 +24,7 @@ memflow = { version = "0.1", path = "../memflow", default-features = false }
 log = { version = "0.4", default-features = false }
 pelite = { version = "0.9", default-features = false }
 goblin = { version = "0.4", default-features = false, features = ["pe32", "pe64"] }
-widestring = { version = "0.4", default-features = false, features = ["alloc"] }
+widestring = { version = "0.5", default-features = false, features = ["alloc"] }
 no-std-compat = { version = "0.4", features = ["alloc"] }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 simple_logger = { version = "1.11.0", optional = true }
@@ -33,7 +33,7 @@ simple_logger = { version = "1.11.0", optional = true }
 regex = { version = "1", optional = true }
 
 # symbolstore
-dirs = { version = "3.0", optional = true }
+dirs = { version = "4.0", optional = true }
 ureq = { version = "2.1", optional = true }
 pdb = { version = "0.7", optional = true }
 pbr = { version = "1.0", optional = true }

--- a/memflow-win32/src/plugins.rs
+++ b/memflow-win32/src/plugins.rs
@@ -13,16 +13,10 @@ pub fn build_kernel(
     args: &Args,
     mem: Option<ConnectorInstanceArcBox<'static>>,
     lib: CArc<c_void>,
-    log_level: log::Level,
 ) -> Result<OsInstanceArcBox<'static>> {
     let mem = mem.ok_or_else(|| {
         Error(ErrorOrigin::OsLayer, ErrorKind::Configuration).log_error("Must provide memory!")
     })?;
-
-    simple_logger::SimpleLogger::new()
-        .with_level(log_level.to_level_filter())
-        .init()
-        .ok();
 
     let builder = Win32Kernel::builder(mem);
     build_dtb(builder, args, lib)

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -52,7 +52,6 @@ cglue_impl_group!(Win32Keyboard<T>, IntoKeyboard);
 #[derive(Clone, Debug)]
 pub struct Win32Keyboard<T> {
     pub virt_mem: T,
-    user_process_info: Win32ProcessInfo,
     key_state_addr: Address,
 }
 
@@ -72,7 +71,6 @@ impl<'a, T: 'static + PhysicalMemory + Clone, V: 'static + VirtualTranslate2 + C
 
         Ok(Self {
             virt_mem,
-            user_process_info,
             key_state_addr,
         })
     }
@@ -108,7 +106,6 @@ impl<'a, T: 'static + PhysicalMemory + Clone, V: 'static + VirtualTranslate2 + C
 
         Ok(Self {
             virt_mem,
-            user_process_info,
             key_state_addr,
         })
     }

--- a/memflow-win32/src/win32/unicode_string.rs
+++ b/memflow-win32/src/win32/unicode_string.rs
@@ -78,8 +78,6 @@ impl<'a, T: MemoryView> VirtualReadUnicodeString for T {
                 Endianess::BigEndian => u16::from_be_bytes(b),
             })
             .collect::<Vec<u16>>();
-        Ok(U16CString::from_vec_with_nul(content16)
-            .map_err(|_| Error(ErrorOrigin::OsLayer, ErrorKind::Encoding))?
-            .to_string_lossy())
+        Ok(U16CString::from_vec_truncate(content16).to_string_lossy())
     }
 }

--- a/memflow/Cargo.toml
+++ b/memflow/Cargo.toml
@@ -23,7 +23,7 @@ log = { version = "0.4", default-features = false }
 bitflags = "1.2"
 coarsetime = { version = "0.1", optional = true }
 smallvec = { version = "1.4", default-features = false }
-x86_64 = { version = "0.14.2", default-features = false }
+x86_64 = { version = "0.14.7", default-features = false }
 rand = { version = "0.8", optional = true }
 rand_xorshift = { version = "0.3", optional = true }
 bumpalo = { version = "3.6", features = ["collections"] }
@@ -38,7 +38,7 @@ rangemap = "0.1.13"
 
 # plugins
 libloading = { version = "0.7", optional = true }
-dirs = { version = "3.0", optional = true }
+dirs = { version = "4.0", optional = true }
 goblin = { version = "0.4", optional = true }
 abi_stable = { version = "0.10", git = "https://github.com/rodrimati1992/abi_stable_crates", optional = true }
 once_cell = { version = "1", optional = true }

--- a/memflow/Cargo.toml
+++ b/memflow/Cargo.toml
@@ -32,8 +32,8 @@ itertools = { version = "0.10", default-features = false }
 memmap = { version = "0.7", optional = true }
 hashbrown = "0.11"
 fixed-slice-vec = "0.8.0"
-#cglue = { version = "0.2.0", git = "https://github.com/h33p/cglue", branch = "main", default-features = false }
-cglue = { path = "../../cglue/cglue", default-features = false }
+cglue = { version = "0.2.0", git = "https://github.com/h33p/cglue", branch = "main", default-features = false }
+#cglue = { path = "../../cglue/cglue", default-features = false }
 rangemap = "0.1.13"
 
 # plugins

--- a/memflow/Cargo.toml
+++ b/memflow/Cargo.toml
@@ -19,7 +19,7 @@ codecov = { repository = "github", branch = "master", service = "github" }
 [dependencies]
 memflow-derive = { version = "0.1", path = "../memflow-derive" }
 dataview = { version = "0.1", default-features = false }
-log = "0.4"
+log = { version = "0.4", default-features = false }
 bitflags = "1.2"
 coarsetime = { version = "0.1", optional = true }
 smallvec = { version = "1.4", default-features = false }
@@ -32,7 +32,8 @@ itertools = { version = "0.10", default-features = false }
 memmap = { version = "0.7", optional = true }
 hashbrown = "0.11"
 fixed-slice-vec = "0.8.0"
-cglue = { version = "0.2.0", git = "https://github.com/h33p/cglue", branch = "main", default-features = false }
+#cglue = { version = "0.2.0", git = "https://github.com/h33p/cglue", branch = "main", default-features = false }
+cglue = { path = "../../cglue/cglue", default-features = false }
 rangemap = "0.1.13"
 
 # plugins
@@ -59,7 +60,7 @@ dummy_mem = ["rand", "rand_xorshift"]
 std = ["coarsetime", "no-std-compat/std", "cglue/std"]
 serde_derive = ["serde", "cglue/serde"]
 memmapfiles = ["toml", "serde_derive"]
-plugins = ["libloading", "dirs", "goblin", "abi_stable", "cglue/layout_checks"]
+plugins = ["libloading", "dirs", "goblin", "abi_stable", "cglue/layout_checks", "log/std"]
 filemap = ["memmap"]
 64_bit_mem = []
 # use 128 bit addressing.

--- a/memflow/Cargo.toml
+++ b/memflow/Cargo.toml
@@ -41,6 +41,7 @@ libloading = { version = "0.7", optional = true }
 dirs = { version = "3.0", optional = true }
 goblin = { version = "0.4", optional = true }
 abi_stable = { version = "0.10", git = "https://github.com/rodrimati1992/abi_stable_crates", optional = true }
+once_cell = { version = "1", optional = true }
 
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive", "alloc"] }
 toml = { version = "0.5", optional = true }
@@ -60,7 +61,7 @@ dummy_mem = ["rand", "rand_xorshift"]
 std = ["coarsetime", "no-std-compat/std", "cglue/std"]
 serde_derive = ["serde", "cglue/serde"]
 memmapfiles = ["toml", "serde_derive"]
-plugins = ["libloading", "dirs", "goblin", "abi_stable", "cglue/layout_checks", "log/std"]
+plugins = ["libloading", "dirs", "goblin", "abi_stable", "cglue/layout_checks", "log/std", "once_cell"]
 filemap = ["memmap"]
 64_bit_mem = []
 # use 128 bit addressing.

--- a/memflow/examples/process_list.rs
+++ b/memflow/examples/process_list.rs
@@ -7,8 +7,8 @@ fn main() -> Result<()> {
     let (conn_name, conn_args, os_name, os_args) = parse_args()?;
 
     // create connector + os
-    let inventory = Inventory::scan();
     let mut os = {
+        let inventory = Inventory::scan();
         let builder = inventory.builder();
 
         if let Some(conn_name) = conn_name {

--- a/memflow/src/dummy/mem.rs
+++ b/memflow/src/dummy/mem.rs
@@ -10,18 +10,16 @@ use crate::mem::{
 use crate::plugins::*;
 use crate::types::{size, umem, Address};
 
-use std::sync::Arc;
-
 cglue_impl_group!(DummyMemory, ConnectorInstance, {});
 
 pub struct DummyMemory {
-    pub(crate) buf: Arc<Box<[u8]>>,
+    pub(crate) buf: Box<[u8]>,
     pub(crate) mem: MappedPhysicalMemory<&'static mut [u8], MemoryMap<&'static mut [u8]>>,
 }
 
 impl DummyMemory {
     pub fn new(size: usize) -> Self {
-        let buf = Arc::new(vec![0_u8; size].into_boxed_slice());
+        let buf = vec![0_u8; size].into_boxed_slice();
 
         let mut map = MemoryMap::new();
         map.push_range(

--- a/memflow/src/dummy/os.rs
+++ b/memflow/src/dummy/os.rs
@@ -559,7 +559,7 @@ extern "C" fn mf_create(
     args: &ReprCString,
     mem: COption<ConnectorInstanceArcBox>,
     lib: CArc<c_void>,
-    logger: PluginLogger,
+    logger: Option<&'static PluginLogger>,
     out: &mut MuOsInstanceArcBox<'static>,
 ) -> i32 {
     create_bare(args, mem.into(), lib, logger, out, build_dummy)

--- a/memflow/src/dummy/os.rs
+++ b/memflow/src/dummy/os.rs
@@ -13,7 +13,6 @@ use crate::plugins::*;
 use crate::types::{clamp_to_usize, imem, mem, size, umem, Address};
 
 use crate::cglue::*;
-use log::Level;
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
@@ -560,17 +559,16 @@ extern "C" fn mf_create(
     args: &ReprCString,
     mem: COption<ConnectorInstanceArcBox>,
     lib: CArc<c_void>,
-    log_level: i32,
+    logger: PluginLogger,
     out: &mut MuOsInstanceArcBox<'static>,
 ) -> i32 {
-    create_bare(args, mem.into(), lib, log_level, out, build_dummy)
+    create_bare(args, mem.into(), lib, logger, out, build_dummy)
 }
 
 pub fn build_dummy(
     args: &Args,
     _mem: Option<ConnectorInstanceArcBox>,
     lib: CArc<c_void>,
-    _log_level: Level,
 ) -> Result<OsInstanceArcBox<'static>> {
     let size = super::mem::parse_size(args)?;
     let mem = DummyMemory::new(size);

--- a/memflow/src/dummy/os.rs
+++ b/memflow/src/dummy/os.rs
@@ -241,7 +241,7 @@ impl DummyOs {
     }
 
     pub fn vtop(&mut self, dtb_base: Address, virt_addr: Address) -> Option<Address> {
-        let mut pml4 = unsafe {
+        let pml4 = unsafe {
             &mut *(self
                 .mem
                 .buf
@@ -251,7 +251,7 @@ impl DummyOs {
         };
 
         let pt_mapper =
-            unsafe { OffsetPageTable::new(&mut pml4, VirtAddr::from_ptr(self.mem.buf.as_ptr())) };
+            unsafe { OffsetPageTable::new(pml4, VirtAddr::from_ptr(self.mem.buf.as_ptr())) };
 
         pt_mapper
             .translate_addr(VirtAddr::new(virt_addr.to_umem() as u64))
@@ -325,7 +325,7 @@ impl DummyOs {
 
         let dtb = self.alloc_pt_page();
 
-        let mut pml4 = unsafe {
+        let pml4 = unsafe {
             &mut *(self
                 .mem
                 .buf
@@ -336,7 +336,7 @@ impl DummyOs {
         *pml4 = PageTable::new();
 
         let mut pt_mapper =
-            unsafe { OffsetPageTable::new(&mut pml4, VirtAddr::from_ptr(self.mem.buf.as_ptr())) };
+            unsafe { OffsetPageTable::new(pml4, VirtAddr::from_ptr(self.mem.buf.as_ptr())) };
 
         while cur_len < map_size {
             let page_info = self.next_page_for_address(cur_len.into());

--- a/memflow/src/iter/double_buffered_iterator.rs
+++ b/memflow/src/iter/double_buffered_iterator.rs
@@ -39,7 +39,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         //If empty, buffer up the output deque
         if self.buf_out.is_empty() {
-            while let Some(elem) = self.iter.next() {
+            for elem in self.iter.by_ref() {
                 match (self.fi)(elem) {
                     (true, elem) => {
                         self.buf.push_back(elem);

--- a/memflow/src/plugins/args.rs
+++ b/memflow/src/plugins/args.rs
@@ -103,15 +103,13 @@ impl Args {
         let mut split = vec![];
         for (i, kv) in quotes.clone().enumerate() {
             if i % 2 == 0 {
-                let s = kv.split(",");
+                let s = kv.split(',');
                 split.extend(s.map(|s| s.to_owned()));
+            } else if split.is_empty() {
+                split.push(kv.to_owned());
             } else {
-                if split.is_empty() {
-                    split.push(kv.to_owned());
-                } else {
-                    let prev = split.pop().unwrap();
-                    map.insert(prev[..prev.len() - 1].to_string(), kv.to_string());
-                }
+                let prev = split.pop().unwrap();
+                map.insert(prev[..prev.len() - 1].to_string(), kv.to_string());
             }
         }
 

--- a/memflow/src/plugins/args.rs
+++ b/memflow/src/plugins/args.rs
@@ -508,7 +508,6 @@ mod tests {
         assert_eq!(args2.get("opt3").unwrap(), "test3");
     }
 
-    // TODO: test non default first to string
     #[test]
     pub fn to_string_with_default() {
         let argstr = "test0,opt1=test1,opt2=test2,opt3=test3";

--- a/memflow/src/plugins/logger.rs
+++ b/memflow/src/plugins/logger.rs
@@ -1,0 +1,143 @@
+/// The plugin logger is just a thin wrapper which redirects all
+/// logging functions from the callee to the caller
+use crate::cglue::{COption, ReprCString};
+
+use log::{Level, SetLoggerError};
+
+/// FFI-Safe representation of log::Metadata
+#[repr(C)]
+pub struct Metadata {
+    level: i32,
+    target: ReprCString,
+}
+
+/// FFI-Safe representation of log::Record
+#[repr(C)]
+pub struct Record {
+    metadata: Metadata,
+    message: ReprCString,
+    module_path: COption<ReprCString>,
+    file: COption<ReprCString>,
+    line: COption<u32>,
+    //#[cfg(feature = "kv_unstable")]
+    //key_values: KeyValues<'a>,
+}
+
+/// A logger which just forwards all calls over the ffi from the callee to the caller.
+#[repr(C)]
+pub struct PluginLogger {
+    max_level: i32,
+    enabled: extern "C" fn(metadata: &Metadata) -> i32,
+    log: extern "C" fn(record: &Record) -> (),
+    flush: extern "C" fn() -> (),
+}
+
+impl PluginLogger {
+    /// Creates a new PluginLogger. This function has to be called on the caller side.
+    pub fn new() -> Self {
+        Self {
+            max_level: log::max_level() as i32,
+            enabled: mf_log_enabled,
+            log: mf_log_log,
+            flush: mf_log_flush,
+        }
+    }
+
+    /// Actually initializes the logger and sets up the log crate.
+    /// This function has to be invoked on the callee side.
+    pub fn init(self) -> Result<(), SetLoggerError> {
+        log::set_max_level(i32_to_level(self.max_level).to_level_filter());
+        // TODO: move to https://docs.rs/log/latest/log/fn.set_logger.html
+        log::set_boxed_logger(Box::new(self))?;
+        Ok(())
+    }
+}
+
+impl Default for PluginLogger {
+    fn default() -> Self {
+        PluginLogger::new()
+    }
+}
+
+impl log::Log for PluginLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        let m = Metadata {
+            level: metadata.level() as i32,
+            target: metadata.target().into(),
+        };
+        (self.enabled)(&m) != 0
+    }
+
+    fn log(&self, record: &log::Record) {
+        let r = Record {
+            metadata: Metadata {
+                level: record.metadata().level() as i32,
+                target: record.metadata().target().into(),
+            },
+            message: format!("{}", record.args()).into(),
+            module_path: record.module_path().map(|s| s.into()).into(),
+            file: record.file().map(|s| s.into()).into(),
+            line: record.line().map(|s| s.into()).into(),
+        };
+        (self.log)(&r)
+    }
+
+    fn flush(&self) {
+        (self.flush)()
+    }
+}
+
+extern "C" fn mf_log_enabled(metadata: &Metadata) -> i32 {
+    match log::logger().enabled(
+        &log::Metadata::builder()
+            .level(i32_to_level(metadata.level))
+            .target(metadata.target.as_ref())
+            .build(),
+    ) {
+        true => 1,
+        false => 0,
+    }
+}
+
+extern "C" fn mf_log_log(record: &Record) {
+    log::logger().log(
+        &log::Record::builder()
+            .metadata(
+                log::Metadata::builder()
+                    .level(i32_to_level(record.metadata.level))
+                    .target(record.metadata.target.as_ref())
+                    .build(),
+            )
+            .args(format_args!("{}", record.message.as_ref()))
+            .module_path(match &record.module_path {
+                COption::Some(s) => Some(s.as_ref()),
+                COption::None => None,
+            })
+            .file(match &record.file {
+                COption::Some(s) => Some(s.as_ref()),
+                COption::None => None,
+            })
+            .line(match &record.line {
+                COption::Some(l) => Some(*l),
+                COption::None => None,
+            })
+            .build(),
+    )
+}
+
+extern "C" fn mf_log_flush() {
+    log::logger().flush()
+}
+
+// internal helper functions to convert from i32 to level
+#[inline]
+fn i32_to_level(level: i32) -> Level {
+    match level {
+        1 => Level::Error,
+        2 => Level::Warn,
+        3 => Level::Info,
+        4 => Level::Debug,
+        5 => Level::Trace,
+        _ => Level::Trace,
+    }
+}

--- a/memflow/src/plugins/logger.rs
+++ b/memflow/src/plugins/logger.rs
@@ -86,7 +86,7 @@ impl log::Log for PluginLogger {
             message: format!("{}", record.args()).into(),
             module_path: record.module_path().map(|s| s.into()).into(),
             file: record.file().map(|s| s.into()).into(),
-            line: record.line().map(|s| s.into()).into(),
+            line: record.line().into(),
         };
         (self.log)(&r)
     }

--- a/memflow/src/plugins/mod.rs
+++ b/memflow/src/plugins/mod.rs
@@ -366,7 +366,7 @@ impl Inventory {
         let path_iter = path_iter.chain(
             path_var
                 .as_ref()
-                .map(|p| std::env::split_paths(p))
+                .map(std::env::split_paths)
                 .into_iter()
                 .flatten(),
         );
@@ -605,7 +605,7 @@ impl Inventory {
     /// use memflow::mem::phys_mem::*;
     ///
     /// #[connector(name = "dummy_conn")]
-    /// pub fn create_connector(_args: &Args, _log_level: log::Level) -> Result<DummyMemory> {
+    /// pub fn create_connector(_args: &Args) -> Result<DummyMemory> {
     ///     Ok(DummyMemory::new(size::mb(16)))
     /// }
     /// ```

--- a/memflow/src/plugins/mod.rs
+++ b/memflow/src/plugins/mod.rs
@@ -235,8 +235,7 @@ pub trait Loadable: Sized {
                 Error(ErrorOrigin::Inventory, ErrorKind::UnableToLoadLibrary)
             })
             .map(LibContext::from)
-            .map(CArc::from)?
-            .into();
+            .map(CArc::from)?;
 
         Ok(exports
             .into_iter()
@@ -731,7 +730,14 @@ impl Inventory {
         lib.loader.instantiate(lib.library.clone(), input, args)
     }
 
-    pub fn update_max_log_level(&self) {
+    /// Sets the maximum logging level in all plugins and updates the
+    /// internal [`PluginLogger`] in each plugin instance.
+    pub fn set_max_log_level(&self, level: LevelFilter) {
+        log::set_max_level(level);
+        self.update_max_log_level()
+    }
+
+    fn update_max_log_level(&self) {
         let level = log::max_level();
 
         self.connectors
@@ -741,11 +747,6 @@ impl Inventory {
             .filter_map(|l| *l)
             .filter_map(LibContext::try_get_logger)
             .for_each(|l| l.on_level_change(level));
-    }
-
-    pub fn set_max_log_level(&self, level: LevelFilter) {
-        log::set_max_level(level);
-        self.update_max_log_level()
     }
 }
 

--- a/memflow/src/plugins/mod.rs
+++ b/memflow/src/plugins/mod.rs
@@ -23,6 +23,9 @@ pub mod os;
 pub use os::{LoadableOs, OsDescriptor};
 pub type OsInputArg = <LoadableOs as Loadable>::InputArg;
 
+pub mod logger;
+pub use logger::*; // TODO: restrict
+
 pub(crate) mod util;
 pub use util::create_bare;
 
@@ -39,7 +42,7 @@ use abi_stable::{type_layout::TypeLayout, StableAbi};
 use libloading::Library;
 
 /// Exported memflow plugins version
-pub const MEMFLOW_PLUGIN_VERSION: i32 = -6;
+pub const MEMFLOW_PLUGIN_VERSION: i32 = -7;
 
 /// Help and Target callbacks
 pub type HelpCallback<'a> = OpaqueCallback<'a, ReprCString>;
@@ -96,7 +99,7 @@ pub type CreateFn<T> = extern "C" fn(
     &ReprCString,
     <T as Loadable>::CInputArg,
     lib: CArc<c_void>,
-    i32,
+    logger: PluginLogger,
     &mut MaybeUninit<<T as Loadable>::Instance>,
 ) -> i32;
 

--- a/memflow/src/plugins/os.rs
+++ b/memflow/src/plugins/os.rs
@@ -3,11 +3,11 @@ use crate::error::*;
 use crate::os::Os;
 
 use super::{
-    Args, ConnectorInstanceArcBox, Loadable, MuOsInstanceArcBox, OsInstance, OsInstanceArcBox,
-    OsInstanceBaseArcBox, OsInstanceVtableFiller, PluginDescriptor, PluginLogger, TargetInfo,
+    Args, ConnectorInstanceArcBox, LibContext, Loadable, MuOsInstanceArcBox, OsInstance,
+    OsInstanceArcBox, OsInstanceBaseArcBox, OsInstanceVtableFiller, PluginDescriptor, PluginLogger,
+    TargetInfo,
 };
 
-use libloading::Library;
 use std::ffi::c_void;
 
 pub type OptionArchitectureIdent<'a> = Option<&'a crate::architecture::ArchitectureIdent>;
@@ -18,7 +18,7 @@ pub fn create<
     args: &ReprCString,
     conn: ConnectorInstanceArcBox,
     lib: CArc<c_void>,
-    logger: PluginLogger,
+    logger: Option<&'static PluginLogger>,
     out: &mut MuOsInstanceArcBox<'static>,
     create_fn: impl Fn(&Args, ConnectorInstanceArcBox) -> Result<T>,
 ) -> i32
@@ -90,19 +90,15 @@ impl Loadable for LoadableOs {
     /// The OS is initialized with the arguments provided to this function.
     fn instantiate(
         &self,
-        library: CArc<Library>,
+        library: CArc<LibContext>,
         input: Self::InputArg,
         args: &Args,
     ) -> Result<Self::Instance> {
         let cstr = ReprCString::from(args.to_string());
         let mut out = MuOsInstanceArcBox::uninit();
-        let res = (self.descriptor.create)(
-            &cstr,
-            input.into(),
-            library.into_opaque(),
-            PluginLogger::new(),
-            &mut out,
-        );
+        let logger = library.as_ref().map(|lib| unsafe { lib.get_logger() });
+        let res =
+            (self.descriptor.create)(&cstr, input.into(), library.into_opaque(), logger, &mut out);
         unsafe { from_int_result(res, out) }
     }
 }

--- a/memflow/src/plugins/util.rs
+++ b/memflow/src/plugins/util.rs
@@ -120,7 +120,7 @@ pub fn create_bare<T, I>(
     logger.init().ok();
 
     into_int_out_result(
-        Args::parse(&args)
+        Args::parse(args)
             .map_err(|e| {
                 ::log::error!("error parsing args: {}", e);
                 e
@@ -149,8 +149,5 @@ pub fn create<T>(
 ) -> i32 {
     logger.init().ok();
 
-    into_int_out_result(
-        Args::parse(&args).and_then(|args| create_fn(args, lib)),
-        out,
-    )
+    into_int_out_result(Args::parse(args).and_then(|args| create_fn(args, lib)), out)
 }

--- a/memflow/src/plugins/util.rs
+++ b/memflow/src/plugins/util.rs
@@ -113,11 +113,13 @@ pub fn create_bare<T, I>(
     args: &ReprCString,
     input: I,
     lib: CArc<c_void>,
-    logger: PluginLogger,
+    logger: Option<&'static PluginLogger>,
     out: &mut MaybeUninit<T>,
     create_fn: impl FnOnce(&Args, I, CArc<c_void>) -> Result<T, Error>,
 ) -> i32 {
-    logger.init().ok();
+    if let Some(logger) = logger {
+        logger.init().ok();
+    }
 
     into_int_out_result(
         Args::parse(args)
@@ -143,11 +145,13 @@ pub fn create_bare<T, I>(
 pub fn create<T>(
     args: &ReprCString,
     lib: CArc<c_void>,
-    logger: PluginLogger,
+    logger: Option<&'static PluginLogger>,
     out: &mut MaybeUninit<T>,
     create_fn: impl FnOnce(super::Args, CArc<c_void>) -> Result<T, Error>,
 ) -> i32 {
-    logger.init().ok();
+    if let Some(logger) = logger {
+        logger.init().ok();
+    }
 
     into_int_out_result(Args::parse(args).and_then(|args| create_fn(args, lib)), out)
 }

--- a/nostd-test/Cargo.toml
+++ b/nostd-test/Cargo.toml
@@ -16,8 +16,8 @@ panic = "abort"
 
 [dependencies]
 rlibc = "1.0.0"
-uefi = "0.8.0"
-uefi-services = "0.5.0"
+uefi = "0.13.0"
+uefi-services = { version = "0.10.0", git = "https://github.com/rust-osdev/uefi-rs" }
 log = "0.4"
 memflow = { path = "../memflow", default-features = false }
 memflow-win32 = { path = "../memflow-win32/", default-features = false, features = ["embed_offsets"] }

--- a/nostd-test/src/main.rs
+++ b/nostd-test/src/main.rs
@@ -15,8 +15,8 @@ use log::*;
 use uefi::{Handle, Status};
 
 #[entry]
-fn efi_main(_handle: Handle, st: SystemTable<Boot>) -> Status {
-    uefi_services::init(&st).expect_success("Failed to initialize utilities");
+fn efi_main(_handle: Handle, mut st: SystemTable<Boot>) -> Status {
+    uefi_services::init(&mut st).expect_success("Failed to initialize utilities");
 
     info!("memflow EFI test");
 


### PR DESCRIPTION
This PR redesigns the logging infrastructure of memflow. Plugins now have a special logger instance which allows them to forward all logging calls over the FFI back to the main logger. This allows users to choose their own logging frontend and still allow plugins to use the user supplied logger.