### PR TITLE
Rework memory API, address #82

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memflow"
-version = "0.2.0-beta1"
+version = "0.2.0-beta2"
 dependencies = [
  "abi_stable",
  "bitflags",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "memflow-derive"
-version = "0.2.0-beta1"
+version = "0.2.0-beta2"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "memflow-ffi"
-version = "0.2.0-beta1"
+version = "0.2.0-beta2"
 dependencies = [
  "log",
  "memflow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
 dependencies = [
  "ahash",
 ]
@@ -496,7 +502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -555,9 +561,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.118"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libloading"
@@ -608,7 +614,7 @@ dependencies = [
  "dirs",
  "fixed-slice-vec",
  "goblin",
- "hashbrown",
+ "hashbrown 0.12.0",
  "itertools 0.10.3",
  "libloading",
  "log",
@@ -876,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "rangemap"
-version = "0.1.14"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3929836cb64d09ee7deee59635c3d9bffbc1c0373e247efff6272abd62a11baa"
+checksum = "4556ba17699ec8276a2e73e22c5b846666e06fe9db1228a9d4377e67b5d35fcb"
 
 [[package]]
 name = "rayon"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cglue"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9537a13fdbce0f3ef3fbc55d70dfd93c807c9c71fbdf97950da033ab1ef5a5ad"
+checksum = "b6504256bcb285d53fd267c524816b219ea8eb4b376f8ddde9297483ed77de78"
 dependencies = [
  "abi_stable",
  "cglue-macro",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "cglue-gen"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8693afab1b06d4722b35d51bc4c4ea7a41887e3f95ad4a67b73bb82cf7efe7c1"
+checksum = "6d45b1d0735cf0c3f21ea1ecc666f7d2add6b89e462bee7b8401cf0823eddc64"
 dependencies = [
  "itertools 0.10.3",
  "lazy_static",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "cglue-macro"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a29a3b995b31756072458741810fd9ffe73b0a5fafa6ad08324b463c44ef528"
+checksum = "8285aff09f786d2f084779793728e050af8c446c32f240778d01f7e095c91614"
 dependencies = [
  "cglue-gen",
  "proc-macro2",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "atty",
  "bitflags",
@@ -555,9 +555,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "libloading"
@@ -601,7 +601,7 @@ dependencies = [
  "bitflags",
  "bumpalo",
  "cglue",
- "clap 3.0.14",
+ "clap 3.1.0",
  "coarsetime",
  "colored",
  "dataview",
@@ -809,9 +809,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "9dada8c9981fcf32929c3c0f0cd796a9284aca335565227ed88c83babb1d43dc"
 dependencies = [
  "thiserror",
  "toml",
@@ -837,14 +837,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -864,15 +863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]

--- a/memflow-bench/Cargo.toml
+++ b/memflow-bench/Cargo.toml
@@ -7,14 +7,13 @@ description = "benchmarks for the memflow physical memory introspection framewor
 readme = "README.md"
 homepage = "https://memflow.github.io"
 repository = "https://github.com/memflow/memflow"
-license-file = "../LICENSE"
 license = "MIT"
 keywords = [ "memflow", "introspection", "memory", "dma" ]
 categories = [ "memory-management", "os" ]
 publish = false
 
 [dependencies]
-memflow = { version = "0.2.0-beta1", path = "../memflow", features = ["dummy_mem"] }
+memflow = { version = "^0.2.0-beta", path = "../memflow", features = ["dummy_mem"] }
 log = "^0.4.14"
 rand = "^0.8.4"
 rand_xorshift = "^0.3"
@@ -23,7 +22,7 @@ rand_xorshift = "^0.3"
 criterion = { git = "https://github.com/h33p/criterion.rs.git", branch = "tput" }
 
 [dev-dependencies]
-memflow = { version = "0.2.0-beta1", path = "../memflow", features = ["dummy_mem", "plugins"] }
+memflow = { version = "^0.2.0-beta", path = "../memflow", features = ["dummy_mem", "plugins"] }
 simplelog = "^0.11.1"
 
 [features]

--- a/memflow-bench/src/vat.rs
+++ b/memflow-bench/src/vat.rs
@@ -19,11 +19,11 @@ fn vat_test_with_mem(
 ) {
     let mut rng = CurRng::from_rng(thread_rng()).unwrap();
 
-    let mut bufs = vec![MemData(Address::null(), 1); translations];
+    let mut bufs = vec![MemData2(Address::null(), 1); translations];
 
     let base_addr = rng.gen_range(module.base.to_umem()..(module.base.to_umem() + module.size));
 
-    for MemData(address, _) in bufs.iter_mut() {
+    for MemData2(address, _) in bufs.iter_mut() {
         *address = (base_addr + rng.gen_range(0..0x2000)).into();
     }
 

--- a/memflow-bench/src/virt.rs
+++ b/memflow-bench/src/virt.rs
@@ -1,6 +1,6 @@
 use criterion::*;
 
-use memflow::mem::{MemData, MemoryView};
+use memflow::mem::{MemData2, MemoryView};
 
 use memflow::error::Result;
 use memflow::os::*;
@@ -35,12 +35,12 @@ fn rwtest<T: MemoryView>(
 
                 let mut bufs = Vec::with_capacity(*o);
 
-                for MemData(addr, _) in bufs.iter_mut() {
+                for MemData2(addr, _) in bufs.iter_mut() {
                     *addr = (base_addr + rng.gen_range(0..0x2000)).into();
                 }
 
                 bufs.extend(vbufs.iter_mut().map(|vec| {
-                    MemData(
+                    MemData2(
                         (base_addr + rng.gen_range(0..0x2000)).into(),
                         vec.as_mut_slice().into(),
                     )

--- a/memflow-derive/Cargo.toml
+++ b/memflow-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memflow-derive"
-version = "0.2.0-beta1"
+version = "0.2.0-beta2"
 authors = ["ko1N <ko1N1337@gmail.com>", "Aurimas Blažulionis <0x60@pm.me>"]
 edition = "2018"
 description = "derive macros for the memflow physical memory introspection framework"
@@ -8,7 +8,6 @@ documentation = "https://docs.rs/memflow-derive"
 readme = "README.md"
 homepage = "https://memflow.github.io"
 repository = "https://github.com/memflow/memflow"
-license-file = "../LICENSE"
 license = "MIT"
 keywords = [ "memflow", "introspection", "memory", "dma" ]
 categories = [ "memory-management", "os" ]

--- a/memflow-ffi/Cargo.toml
+++ b/memflow-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memflow-ffi"
-version = "0.2.0-beta1"
+version = "0.2.0-beta2"
 authors = ["ko1N <ko1N1337@gmail.com>", "Aurimas Blažulionis <0x60@pm.me>"]
 edition = "2018"
 description = "C bindings for the memflow physical memory introspection framework"
@@ -8,7 +8,6 @@ documentation = "https://docs.rs/memflow-ffi"
 readme = "README.md"
 homepage = "https://memflow.github.io"
 repository = "https://github.com/memflow/memflow"
-license-file = "../LICENSE"
 license = "MIT"
 keywords = [ "memflow", "introspection", "memory", "dma" ]
 categories = [ "api-bindings", "memory-management", "os" ]
@@ -22,7 +21,7 @@ name = "memflow_ffi"
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-memflow = { version = "0.2.0-beta1", path = "../memflow" }
+memflow = { version = "^0.2.0-beta", path = "../memflow" }
 log = "^0.4.14"
 simplelog = "^0.11.1"
 

--- a/memflow-ffi/memflow.h
+++ b/memflow-ffi/memflow.h
@@ -425,20 +425,21 @@ typedef struct CSliceMut_u8 {
 } CSliceMut_u8;
 
 /**
- * Generic type representing an address and associated data.
+ * Generic type representing an address, original address,and associated data.
  *
  * This base type is always used for initialization, but the commonly used type aliases are:
- * `ReadData`, `WriteData`, `PhysicalReadData`, and `PhysicalWriteData`.
+ * `ReadDataIn`, `WriteDataIn`, `PhysicalReadDataIn`, and `PhysicalWriteDataIn`.
  */
-typedef struct MemData_PhysicalAddress__CSliceMut_u8 {
+typedef struct MemData3_PhysicalAddress__Address__CSliceMut_u8 {
     struct PhysicalAddress _0;
-    struct CSliceMut_u8 _1;
-} MemData_PhysicalAddress__CSliceMut_u8;
+    Address _1;
+    struct CSliceMut_u8 _2;
+} MemData3_PhysicalAddress__Address__CSliceMut_u8;
 
 /**
  * MemData type for physical memory reads.
  */
-typedef struct MemData_PhysicalAddress__CSliceMut_u8 PhysicalReadData;
+typedef struct MemData3_PhysicalAddress__Address__CSliceMut_u8 PhysicalReadData;
 
 /**
  * FFI compatible iterator.
@@ -488,15 +489,12 @@ typedef struct CIterator_PhysicalReadData {
  * This base type is always used for initialization, but the commonly used type aliases are:
  * `ReadData`, `WriteData`, `PhysicalReadData`, and `PhysicalWriteData`.
  */
-typedef struct MemData_Address__CSliceMut_u8 {
+typedef struct MemData2_Address__CSliceMut_u8 {
     Address _0;
     struct CSliceMut_u8 _1;
-} MemData_Address__CSliceMut_u8;
+} MemData2_Address__CSliceMut_u8;
 
-/**
- * MemData type for regular memory reads.
- */
-typedef struct MemData_Address__CSliceMut_u8 ReadData;
+typedef struct MemData2_Address__CSliceMut_u8 ReadData;
 
 typedef struct Callback_c_void__ReadData {
     void *context;
@@ -505,7 +503,18 @@ typedef struct Callback_c_void__ReadData {
 
 typedef struct Callback_c_void__ReadData OpaqueCallback_ReadData;
 
-typedef OpaqueCallback_ReadData ReadFailCallback;
+/**
+ * Data needed to perform memory operations.
+ *
+ * `inp` is an iterator containing
+ */
+typedef struct MemOps_PhysicalReadData__ReadData {
+    struct CIterator_PhysicalReadData inp;
+    OpaqueCallback_ReadData *out;
+    OpaqueCallback_ReadData *out_fail;
+} MemOps_PhysicalReadData__ReadData;
+
+typedef struct MemOps_PhysicalReadData__ReadData PhysicalReadMemOps;
 
 /**
  * Wrapper around const slices.
@@ -535,20 +544,21 @@ typedef struct CSliceRef_u8 {
 } CSliceRef_u8;
 
 /**
- * Generic type representing an address and associated data.
+ * Generic type representing an address, original address,and associated data.
  *
  * This base type is always used for initialization, but the commonly used type aliases are:
- * `ReadData`, `WriteData`, `PhysicalReadData`, and `PhysicalWriteData`.
+ * `ReadDataIn`, `WriteDataIn`, `PhysicalReadDataIn`, and `PhysicalWriteDataIn`.
  */
-typedef struct MemData_PhysicalAddress__CSliceRef_u8 {
+typedef struct MemData3_PhysicalAddress__Address__CSliceRef_u8 {
     struct PhysicalAddress _0;
-    struct CSliceRef_u8 _1;
-} MemData_PhysicalAddress__CSliceRef_u8;
+    Address _1;
+    struct CSliceRef_u8 _2;
+} MemData3_PhysicalAddress__Address__CSliceRef_u8;
 
 /**
  * MemData type for physical memory writes.
  */
-typedef struct MemData_PhysicalAddress__CSliceRef_u8 PhysicalWriteData;
+typedef struct MemData3_PhysicalAddress__Address__CSliceRef_u8 PhysicalWriteData;
 
 /**
  * FFI compatible iterator.
@@ -598,15 +608,12 @@ typedef struct CIterator_PhysicalWriteData {
  * This base type is always used for initialization, but the commonly used type aliases are:
  * `ReadData`, `WriteData`, `PhysicalReadData`, and `PhysicalWriteData`.
  */
-typedef struct MemData_Address__CSliceRef_u8 {
+typedef struct MemData2_Address__CSliceRef_u8 {
     Address _0;
     struct CSliceRef_u8 _1;
-} MemData_Address__CSliceRef_u8;
+} MemData2_Address__CSliceRef_u8;
 
-/**
- * MemData type for regular memory writes.
- */
-typedef struct MemData_Address__CSliceRef_u8 WriteData;
+typedef struct MemData2_Address__CSliceRef_u8 WriteData;
 
 typedef struct Callback_c_void__WriteData {
     void *context;
@@ -615,7 +622,18 @@ typedef struct Callback_c_void__WriteData {
 
 typedef struct Callback_c_void__WriteData OpaqueCallback_WriteData;
 
-typedef OpaqueCallback_WriteData WriteFailCallback;
+/**
+ * Data needed to perform memory operations.
+ *
+ * `inp` is an iterator containing
+ */
+typedef struct MemOps_PhysicalWriteData__WriteData {
+    struct CIterator_PhysicalWriteData inp;
+    OpaqueCallback_WriteData *out;
+    OpaqueCallback_WriteData *out_fail;
+} MemOps_PhysicalWriteData__WriteData;
+
+typedef struct MemOps_PhysicalWriteData__WriteData PhysicalWriteMemOps;
 
 typedef struct PhysicalMemoryMetadata {
     Address max_address;
@@ -656,6 +674,158 @@ typedef struct CSliceRef_PhysicalMemoryMapping {
     const struct PhysicalMemoryMapping *data;
     uintptr_t len;
 } CSliceRef_PhysicalMemoryMapping;
+
+/**
+ * Generic type representing an address, original address,and associated data.
+ *
+ * This base type is always used for initialization, but the commonly used type aliases are:
+ * `ReadDataIn`, `WriteDataIn`, `PhysicalReadDataIn`, and `PhysicalWriteDataIn`.
+ */
+typedef struct MemData3_Address__Address__CSliceMut_u8 {
+    Address _0;
+    Address _1;
+    struct CSliceMut_u8 _2;
+} MemData3_Address__Address__CSliceMut_u8;
+
+/**
+ * MemData type for regular memory reads.
+ */
+typedef struct MemData3_Address__Address__CSliceMut_u8 ReadDataRaw;
+
+/**
+ * FFI compatible iterator.
+ *
+ * Any mutable reference to an iterator can be converted to a `CIterator`.
+ *
+ * `CIterator<T>` implements `Iterator<Item = T>`.
+ *
+ * # Examples
+ *
+ * Using [`AsCIterator`](AsCIterator) helper:
+ *
+ * ```
+ * use cglue::iter::{CIterator, AsCIterator};
+ *
+ * extern "C" fn sum_all(iter: CIterator<usize>) -> usize {
+ *     iter.sum()
+ * }
+ *
+ * let mut iter = (0..10).map(|v| v * v);
+ *
+ * assert_eq!(sum_all(iter.as_citer()), 285);
+ * ```
+ *
+ * Converting with `Into` trait:
+ *
+ * ```
+ * use cglue::iter::{CIterator, AsCIterator};
+ *
+ * extern "C" fn sum_all(iter: CIterator<usize>) -> usize {
+ *     iter.sum()
+ * }
+ *
+ * let mut iter = (0..=10).map(|v| v * v);
+ *
+ * assert_eq!(sum_all((&mut iter).into()), 385);
+ * ```
+ */
+typedef struct CIterator_ReadDataRaw {
+    void *iter;
+    int32_t (*func)(void*, ReadDataRaw *out);
+} CIterator_ReadDataRaw;
+
+/**
+ * Data needed to perform memory operations.
+ *
+ * `inp` is an iterator containing
+ */
+typedef struct MemOps_ReadDataRaw__ReadData {
+    struct CIterator_ReadDataRaw inp;
+    OpaqueCallback_ReadData *out;
+    OpaqueCallback_ReadData *out_fail;
+} MemOps_ReadDataRaw__ReadData;
+
+typedef struct MemOps_ReadDataRaw__ReadData ReadRawMemOps;
+
+/**
+ * Generic type representing an address, original address,and associated data.
+ *
+ * This base type is always used for initialization, but the commonly used type aliases are:
+ * `ReadDataIn`, `WriteDataIn`, `PhysicalReadDataIn`, and `PhysicalWriteDataIn`.
+ */
+typedef struct MemData3_Address__Address__CSliceRef_u8 {
+    Address _0;
+    Address _1;
+    struct CSliceRef_u8 _2;
+} MemData3_Address__Address__CSliceRef_u8;
+
+/**
+ * MemData type for regular memory writes.
+ */
+typedef struct MemData3_Address__Address__CSliceRef_u8 WriteDataRaw;
+
+/**
+ * FFI compatible iterator.
+ *
+ * Any mutable reference to an iterator can be converted to a `CIterator`.
+ *
+ * `CIterator<T>` implements `Iterator<Item = T>`.
+ *
+ * # Examples
+ *
+ * Using [`AsCIterator`](AsCIterator) helper:
+ *
+ * ```
+ * use cglue::iter::{CIterator, AsCIterator};
+ *
+ * extern "C" fn sum_all(iter: CIterator<usize>) -> usize {
+ *     iter.sum()
+ * }
+ *
+ * let mut iter = (0..10).map(|v| v * v);
+ *
+ * assert_eq!(sum_all(iter.as_citer()), 285);
+ * ```
+ *
+ * Converting with `Into` trait:
+ *
+ * ```
+ * use cglue::iter::{CIterator, AsCIterator};
+ *
+ * extern "C" fn sum_all(iter: CIterator<usize>) -> usize {
+ *     iter.sum()
+ * }
+ *
+ * let mut iter = (0..=10).map(|v| v * v);
+ *
+ * assert_eq!(sum_all((&mut iter).into()), 385);
+ * ```
+ */
+typedef struct CIterator_WriteDataRaw {
+    void *iter;
+    int32_t (*func)(void*, WriteDataRaw *out);
+} CIterator_WriteDataRaw;
+
+/**
+ * Data needed to perform memory operations.
+ *
+ * `inp` is an iterator containing
+ */
+typedef struct MemOps_WriteDataRaw__WriteData {
+    struct CIterator_WriteDataRaw inp;
+    OpaqueCallback_WriteData *out;
+    OpaqueCallback_WriteData *out_fail;
+} MemOps_WriteDataRaw__WriteData;
+
+typedef struct MemOps_WriteDataRaw__WriteData WriteRawMemOps;
+
+typedef struct MemoryViewMetadata {
+    Address max_address;
+    umem real_size;
+    bool readonly;
+    bool little_endian;
+    uint8_t arch_bits;
+} MemoryViewMetadata;
 
 /**
  * FFI compatible iterator.
@@ -699,6 +869,19 @@ typedef struct CIterator_ReadData {
     int32_t (*func)(void*, ReadData *out);
 } CIterator_ReadData;
 
+typedef OpaqueCallback_ReadData ReadCallback;
+
+/**
+ * Wrapper around mutable slices.
+ *
+ * This is meant as a safe type to pass across the FFI boundary with similar semantics as regular
+ * slice. However, not all functionality is present, use the slice conversion functions.
+ */
+typedef struct CSliceMut_ReadData {
+    ReadData *data;
+    uintptr_t len;
+} CSliceMut_ReadData;
+
 /**
  * FFI compatible iterator.
  *
@@ -741,24 +924,7 @@ typedef struct CIterator_WriteData {
     int32_t (*func)(void*, WriteData *out);
 } CIterator_WriteData;
 
-typedef struct MemoryViewMetadata {
-    Address max_address;
-    umem real_size;
-    bool readonly;
-    bool little_endian;
-    uint8_t arch_bits;
-} MemoryViewMetadata;
-
-/**
- * Wrapper around mutable slices.
- *
- * This is meant as a safe type to pass across the FFI boundary with similar semantics as regular
- * slice. However, not all functionality is present, use the slice conversion functions.
- */
-typedef struct CSliceMut_ReadData {
-    ReadData *data;
-    uintptr_t len;
-} CSliceMut_ReadData;
+typedef OpaqueCallback_WriteData WriteCallback;
 
 /**
  * Wrapper around const slices.
@@ -1269,17 +1435,18 @@ typedef OpaqueCallback_SectionInfo SectionCallback;
 typedef int64_t imem;
 
 /**
- * Generic type representing an address and associated data.
+ * Generic type representing an address, original address,and associated data.
  *
  * This base type is always used for initialization, but the commonly used type aliases are:
- * `ReadData`, `WriteData`, `PhysicalReadData`, and `PhysicalWriteData`.
+ * `ReadDataIn`, `WriteDataIn`, `PhysicalReadDataIn`, and `PhysicalWriteDataIn`.
  */
-typedef struct MemData_Address__umem {
+typedef struct MemData3_Address__umem__PageType {
     Address _0;
     umem _1;
-} MemData_Address__umem;
+    PageType _2;
+} MemData3_Address__umem__PageType;
 
-typedef struct MemData_Address__umem MemoryRange;
+typedef struct MemData3_Address__umem__PageType MemoryRange;
 
 typedef struct Callback_c_void__MemoryRange {
     void *context;
@@ -1289,6 +1456,19 @@ typedef struct Callback_c_void__MemoryRange {
 typedef struct Callback_c_void__MemoryRange OpaqueCallback_MemoryRange;
 
 typedef OpaqueCallback_MemoryRange MemoryRangeCallback;
+
+/**
+ * Generic type representing an address and associated data.
+ *
+ * This base type is always used for initialization, but the commonly used type aliases are:
+ * `ReadData`, `WriteData`, `PhysicalReadData`, and `PhysicalWriteData`.
+ */
+typedef struct MemData2_Address__umem {
+    Address _0;
+    umem _1;
+} MemData2_Address__umem;
+
+typedef struct MemData2_Address__umem VtopRange;
 
 /**
  * Wrapper around const slices.
@@ -1312,10 +1492,10 @@ typedef OpaqueCallback_MemoryRange MemoryRangeCallback;
  * assert_eq!(&arr, slice);
  * ```
  */
-typedef struct CSliceRef_MemoryRange {
-    const MemoryRange *data;
+typedef struct CSliceRef_VtopRange {
+    const VtopRange *data;
     uintptr_t len;
-} CSliceRef_MemoryRange;
+} CSliceRef_VtopRange;
 
 /**
  * Virtual page range information with physical mappings used for callbacks
@@ -1445,11 +1625,13 @@ typedef struct OsInnerVtbl_OsInstanceContainer_CBox_c_void_____CArc_c_void {
  * This virtual function table contains ABI-safe interface for the given trait.
  */
 typedef struct MemoryViewVtbl_OsInstanceContainer_CBox_c_void_____CArc_c_void {
-    int32_t (*read_raw_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_ReadData data, ReadFailCallback *out_fail);
-    int32_t (*write_raw_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_WriteData data, WriteFailCallback *out_fail);
+    int32_t (*read_raw_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, ReadRawMemOps data);
+    int32_t (*write_raw_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, WriteRawMemOps data);
     struct MemoryViewMetadata (*metadata)(const struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont);
+    int32_t (*read_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_ReadData inp, ReadCallback *out, ReadCallback *out_fail);
     int32_t (*read_raw_list)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceMut_ReadData data);
     int32_t (*read_raw_into)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address addr, struct CSliceMut_u8 out);
+    int32_t (*write_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_WriteData inp, WriteCallback *out, WriteCallback *out_fail);
     int32_t (*write_raw_list)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_WriteData data);
     int32_t (*write_raw)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address addr, struct CSliceRef_u8 data);
 } MemoryViewVtbl_OsInstanceContainer_CBox_c_void_____CArc_c_void;
@@ -1612,8 +1794,8 @@ typedef struct OsKeyboardInnerVtbl_OsInstanceContainer_CBox_c_void_____CArc_c_vo
  * This virtual function table contains ABI-safe interface for the given trait.
  */
 typedef struct PhysicalMemoryVtbl_OsInstanceContainer_CBox_c_void_____CArc_c_void {
-    int32_t (*phys_read_raw_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_PhysicalReadData data, ReadFailCallback *out_fail);
-    int32_t (*phys_write_raw_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_PhysicalWriteData data, WriteFailCallback *out_fail);
+    int32_t (*phys_read_raw_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, PhysicalReadMemOps data);
+    int32_t (*phys_write_raw_iter)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, PhysicalWriteMemOps data);
     struct PhysicalMemoryMetadata (*metadata)(const struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont);
     void (*set_mem_map)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_PhysicalMemoryMapping _mem_map);
     MemoryViewBase_CBox_c_void_____CArc_c_void (*into_phys_view)(struct OsInstanceContainer_CBox_c_void_____CArc_c_void cont);
@@ -1669,11 +1851,13 @@ typedef struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void {
  * This virtual function table contains ABI-safe interface for the given trait.
  */
 typedef struct MemoryViewVtbl_ProcessInstanceContainer_CBox_c_void_____CArc_c_void {
-    int32_t (*read_raw_iter)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_ReadData data, ReadFailCallback *out_fail);
-    int32_t (*write_raw_iter)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_WriteData data, WriteFailCallback *out_fail);
+    int32_t (*read_raw_iter)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, ReadRawMemOps data);
+    int32_t (*write_raw_iter)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, WriteRawMemOps data);
     struct MemoryViewMetadata (*metadata)(const struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont);
+    int32_t (*read_iter)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_ReadData inp, ReadCallback *out, ReadCallback *out_fail);
     int32_t (*read_raw_list)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceMut_ReadData data);
     int32_t (*read_raw_into)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address addr, struct CSliceMut_u8 out);
+    int32_t (*write_iter)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_WriteData inp, WriteCallback *out, WriteCallback *out_fail);
     int32_t (*write_raw_list)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_WriteData data);
     int32_t (*write_raw)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address addr, struct CSliceRef_u8 data);
 } MemoryViewVtbl_ProcessInstanceContainer_CBox_c_void_____CArc_c_void;
@@ -1709,7 +1893,7 @@ typedef struct ProcessVtbl_ProcessInstanceContainer_CBox_c_void_____CArc_c_void 
  * This virtual function table contains ABI-safe interface for the given trait.
  */
 typedef struct VirtualTranslateVtbl_ProcessInstanceContainer_CBox_c_void_____CArc_c_void {
-    void (*virt_to_phys_list)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_MemoryRange addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail);
+    void (*virt_to_phys_list)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_VtopRange addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail);
     void (*virt_to_phys_range)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address start, Address end, VirtualTranslationCallback out);
     void (*virt_translation_map_range)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address start, Address end, VirtualTranslationCallback out);
     void (*virt_page_map_range)(struct ProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, imem gap_size, Address start, Address end, MemoryRangeCallback out);
@@ -1774,11 +1958,13 @@ typedef struct CloneVtbl_IntoProcessInstanceContainer_CBox_c_void_____CArc_c_voi
  * This virtual function table contains ABI-safe interface for the given trait.
  */
 typedef struct MemoryViewVtbl_IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void {
-    int32_t (*read_raw_iter)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_ReadData data, ReadFailCallback *out_fail);
-    int32_t (*write_raw_iter)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_WriteData data, WriteFailCallback *out_fail);
+    int32_t (*read_raw_iter)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, ReadRawMemOps data);
+    int32_t (*write_raw_iter)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, WriteRawMemOps data);
     struct MemoryViewMetadata (*metadata)(const struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont);
+    int32_t (*read_iter)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_ReadData inp, ReadCallback *out, ReadCallback *out_fail);
     int32_t (*read_raw_list)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceMut_ReadData data);
     int32_t (*read_raw_into)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address addr, struct CSliceMut_u8 out);
+    int32_t (*write_iter)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_WriteData inp, WriteCallback *out, WriteCallback *out_fail);
     int32_t (*write_raw_list)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_WriteData data);
     int32_t (*write_raw)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address addr, struct CSliceRef_u8 data);
 } MemoryViewVtbl_IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void;
@@ -1814,7 +2000,7 @@ typedef struct ProcessVtbl_IntoProcessInstanceContainer_CBox_c_void_____CArc_c_v
  * This virtual function table contains ABI-safe interface for the given trait.
  */
 typedef struct VirtualTranslateVtbl_IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void {
-    void (*virt_to_phys_list)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_MemoryRange addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail);
+    void (*virt_to_phys_list)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_VtopRange addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail);
     void (*virt_to_phys_range)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address start, Address end, VirtualTranslationCallback out);
     void (*virt_translation_map_range)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, Address start, Address end, VirtualTranslationCallback out);
     void (*virt_page_map_range)(struct IntoProcessInstanceContainer_CBox_c_void_____CArc_c_void *cont, imem gap_size, Address start, Address end, MemoryRangeCallback out);
@@ -1886,11 +2072,13 @@ typedef struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTm
  * This virtual function table contains ABI-safe interface for the given trait.
  */
 typedef struct MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void {
-    int32_t (*read_raw_iter)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, struct CIterator_ReadData data, ReadFailCallback *out_fail);
-    int32_t (*write_raw_iter)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, struct CIterator_WriteData data, WriteFailCallback *out_fail);
+    int32_t (*read_raw_iter)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, ReadRawMemOps data);
+    int32_t (*write_raw_iter)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, WriteRawMemOps data);
     struct MemoryViewMetadata (*metadata)(const struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont);
+    int32_t (*read_iter)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, struct CIterator_ReadData inp, ReadCallback *out, ReadCallback *out_fail);
     int32_t (*read_raw_list)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, struct CSliceMut_ReadData data);
     int32_t (*read_raw_into)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, Address addr, struct CSliceMut_u8 out);
+    int32_t (*write_iter)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, struct CIterator_WriteData inp, WriteCallback *out, WriteCallback *out_fail);
     int32_t (*write_raw_list)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, struct CSliceRef_WriteData data);
     int32_t (*write_raw)(struct CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void *cont, Address addr, struct CSliceRef_u8 data);
 } MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void;
@@ -1915,8 +2103,8 @@ typedef struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CB
  * This virtual function table contains ABI-safe interface for the given trait.
  */
 typedef struct PhysicalMemoryVtbl_ConnectorInstanceContainer_CBox_c_void_____CArc_c_void {
-    int32_t (*phys_read_raw_iter)(struct ConnectorInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_PhysicalReadData data, ReadFailCallback *out_fail);
-    int32_t (*phys_write_raw_iter)(struct ConnectorInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CIterator_PhysicalWriteData data, WriteFailCallback *out_fail);
+    int32_t (*phys_read_raw_iter)(struct ConnectorInstanceContainer_CBox_c_void_____CArc_c_void *cont, PhysicalReadMemOps data);
+    int32_t (*phys_write_raw_iter)(struct ConnectorInstanceContainer_CBox_c_void_____CArc_c_void *cont, PhysicalWriteMemOps data);
     struct PhysicalMemoryMetadata (*metadata)(const struct ConnectorInstanceContainer_CBox_c_void_____CArc_c_void *cont);
     void (*set_mem_map)(struct ConnectorInstanceContainer_CBox_c_void_____CArc_c_void *cont, struct CSliceRef_PhysicalMemoryMapping _mem_map);
     MemoryViewBase_CBox_c_void_____CArc_c_void (*into_phys_view)(struct ConnectorInstanceContainer_CBox_c_void_____CArc_c_void cont);
@@ -2226,18 +2414,23 @@ static inline void mf_keyboard_drop(struct CGlueTraitObj_CBox_c_void_____Keyboar
 
 }
 
-static inline int32_t mf_read_raw_iter(void *self, struct CIterator_ReadData data, ReadFailCallback * out_fail)  {
-    int32_t __ret = (((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->vtbl)->read_raw_iter(&((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_read_raw_iter(void *self, ReadRawMemOps data)  {
+    int32_t __ret = (((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->vtbl)->read_raw_iter(&((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->container, data);
     return __ret;
 }
 
-static inline int32_t mf_write_raw_iter(void *self, struct CIterator_WriteData data, WriteFailCallback * out_fail)  {
-    int32_t __ret = (((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->vtbl)->write_raw_iter(&((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_write_raw_iter(void *self, WriteRawMemOps data)  {
+    int32_t __ret = (((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->vtbl)->write_raw_iter(&((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->container, data);
     return __ret;
 }
 
 static inline struct MemoryViewMetadata mf_metadata(const void *self)  {
     struct MemoryViewMetadata __ret = (((const struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->vtbl)->metadata(&((const struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->container);
+    return __ret;
+}
+
+static inline int32_t mf_read_iter(void *self, struct CIterator_ReadData inp, ReadCallback * out, ReadCallback * out_fail)  {
+    int32_t __ret = (((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->vtbl)->read_iter(&((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->container, inp, out, out_fail);
     return __ret;
 }
 
@@ -2248,6 +2441,11 @@ static inline int32_t mf_read_raw_list(void *self, struct CSliceMut_ReadData dat
 
 static inline int32_t mf_read_raw_into(void *self, Address addr, struct CSliceMut_u8 out)  {
     int32_t __ret = (((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->vtbl)->read_raw_into(&((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->container, addr, out);
+    return __ret;
+}
+
+static inline int32_t mf_write_iter(void *self, struct CIterator_WriteData inp, WriteCallback * out, WriteCallback * out_fail)  {
+    int32_t __ret = (((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->vtbl)->write_iter(&((struct CGlueTraitObj_CBox_c_void_____MemoryViewVtbl_CGlueObjContainer_CBox_c_void_____CArc_c_void_____MemoryViewRetTmp_CArc_c_void______________CArc_c_void_____MemoryViewRetTmp_CArc_c_void *)self)->container, inp, out, out_fail);
     return __ret;
 }
 
@@ -2423,18 +2621,23 @@ static inline const struct OsInfo * mf_osinstance_info(const void *self)  {
     return __ret;
 }
 
-static inline int32_t mf_osinstance_read_raw_iter(void *self, struct CIterator_ReadData data, ReadFailCallback * out_fail)  {
-    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_osinstance_read_raw_iter(void *self, ReadRawMemOps data)  {
+    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
-static inline int32_t mf_osinstance_write_raw_iter(void *self, struct CIterator_WriteData data, WriteFailCallback * out_fail)  {
-    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_raw_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_osinstance_write_raw_iter(void *self, WriteRawMemOps data)  {
+    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_raw_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
 static inline struct MemoryViewMetadata mf_osinstance_metadata(const void *self)  {
     struct MemoryViewMetadata __ret = (((const struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->metadata(&((const struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container);
+    return __ret;
+}
+
+static inline int32_t mf_osinstance_read_iter(void *self, struct CIterator_ReadData inp, ReadCallback * out, ReadCallback * out_fail)  {
+    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, inp, out, out_fail);
     return __ret;
 }
 
@@ -2445,6 +2648,11 @@ static inline int32_t mf_osinstance_read_raw_list(void *self, struct CSliceMut_R
 
 static inline int32_t mf_osinstance_read_raw_into(void *self, Address addr, struct CSliceMut_u8 out)  {
     int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_into(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, addr, out);
+    return __ret;
+}
+
+static inline int32_t mf_osinstance_write_iter(void *self, struct CIterator_WriteData inp, WriteCallback * out, WriteCallback * out_fail)  {
+    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, inp, out, out_fail);
     return __ret;
 }
 
@@ -2497,13 +2705,13 @@ static inline int32_t mf_osinstance_into_keyboard(struct OsInstance_CBox_c_void_
     return __ret;
 }
 
-static inline int32_t mf_osinstance_phys_read_raw_iter(void *self, struct CIterator_PhysicalReadData data, ReadFailCallback * out_fail)  {
-    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_physicalmemory)->phys_read_raw_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_osinstance_phys_read_raw_iter(void *self, PhysicalReadMemOps data)  {
+    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_physicalmemory)->phys_read_raw_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
-static inline int32_t mf_osinstance_phys_write_raw_iter(void *self, struct CIterator_PhysicalWriteData data, WriteFailCallback * out_fail)  {
-    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_physicalmemory)->phys_write_raw_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_osinstance_phys_write_raw_iter(void *self, PhysicalWriteMemOps data)  {
+    int32_t __ret = (((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_physicalmemory)->phys_write_raw_iter(&((struct OsInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
@@ -2524,18 +2732,23 @@ static inline MemoryViewBase_CBox_c_void_____CArc_c_void mf_osinstance_phys_view
     return __ret;
 }
 
-static inline int32_t mf_processinstance_read_raw_iter(void *self, struct CIterator_ReadData data, ReadFailCallback * out_fail)  {
-    int32_t __ret = (((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_iter(&((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_processinstance_read_raw_iter(void *self, ReadRawMemOps data)  {
+    int32_t __ret = (((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_iter(&((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
-static inline int32_t mf_processinstance_write_raw_iter(void *self, struct CIterator_WriteData data, WriteFailCallback * out_fail)  {
-    int32_t __ret = (((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_raw_iter(&((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_processinstance_write_raw_iter(void *self, WriteRawMemOps data)  {
+    int32_t __ret = (((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_raw_iter(&((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
 static inline struct MemoryViewMetadata mf_processinstance_metadata(const void *self)  {
     struct MemoryViewMetadata __ret = (((const struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->metadata(&((const struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container);
+    return __ret;
+}
+
+static inline int32_t mf_processinstance_read_iter(void *self, struct CIterator_ReadData inp, ReadCallback * out, ReadCallback * out_fail)  {
+    int32_t __ret = (((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_iter(&((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, inp, out, out_fail);
     return __ret;
 }
 
@@ -2546,6 +2759,11 @@ static inline int32_t mf_processinstance_read_raw_list(void *self, struct CSlice
 
 static inline int32_t mf_processinstance_read_raw_into(void *self, Address addr, struct CSliceMut_u8 out)  {
     int32_t __ret = (((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_into(&((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, addr, out);
+    return __ret;
+}
+
+static inline int32_t mf_processinstance_write_iter(void *self, struct CIterator_WriteData inp, WriteCallback * out, WriteCallback * out_fail)  {
+    int32_t __ret = (((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_iter(&((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, inp, out, out_fail);
     return __ret;
 }
 
@@ -2650,7 +2868,7 @@ static inline void mf_processinstance_mapped_mem(void *self, imem gap_size, Memo
 
 }
 
-static inline void mf_processinstance_virt_to_phys_list(void *self, struct CSliceRef_MemoryRange addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail)  {
+static inline void mf_processinstance_virt_to_phys_list(void *self, struct CSliceRef_VtopRange addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail)  {
 (((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_virtualtranslate)->virt_to_phys_list(&((struct ProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, addrs, out, out_fail);
 
 }
@@ -2707,18 +2925,23 @@ static inline void mf_intoprocessinstance_drop(struct IntoProcessInstance_CBox_c
 
 }
 
-static inline int32_t mf_intoprocessinstance_read_raw_iter(void *self, struct CIterator_ReadData data, ReadFailCallback * out_fail)  {
-    int32_t __ret = (((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_iter(&((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_intoprocessinstance_read_raw_iter(void *self, ReadRawMemOps data)  {
+    int32_t __ret = (((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_iter(&((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
-static inline int32_t mf_intoprocessinstance_write_raw_iter(void *self, struct CIterator_WriteData data, WriteFailCallback * out_fail)  {
-    int32_t __ret = (((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_raw_iter(&((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_intoprocessinstance_write_raw_iter(void *self, WriteRawMemOps data)  {
+    int32_t __ret = (((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_raw_iter(&((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
 static inline struct MemoryViewMetadata mf_intoprocessinstance_metadata(const void *self)  {
     struct MemoryViewMetadata __ret = (((const struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->metadata(&((const struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container);
+    return __ret;
+}
+
+static inline int32_t mf_intoprocessinstance_read_iter(void *self, struct CIterator_ReadData inp, ReadCallback * out, ReadCallback * out_fail)  {
+    int32_t __ret = (((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_iter(&((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, inp, out, out_fail);
     return __ret;
 }
 
@@ -2729,6 +2952,11 @@ static inline int32_t mf_intoprocessinstance_read_raw_list(void *self, struct CS
 
 static inline int32_t mf_intoprocessinstance_read_raw_into(void *self, Address addr, struct CSliceMut_u8 out)  {
     int32_t __ret = (((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->read_raw_into(&((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, addr, out);
+    return __ret;
+}
+
+static inline int32_t mf_intoprocessinstance_write_iter(void *self, struct CIterator_WriteData inp, WriteCallback * out, WriteCallback * out_fail)  {
+    int32_t __ret = (((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_memoryview)->write_iter(&((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, inp, out, out_fail);
     return __ret;
 }
 
@@ -2827,7 +3055,7 @@ static inline void mf_intoprocessinstance_mapped_mem(void *self, imem gap_size, 
 
 }
 
-static inline void mf_intoprocessinstance_virt_to_phys_list(void *self, struct CSliceRef_MemoryRange addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail)  {
+static inline void mf_intoprocessinstance_virt_to_phys_list(void *self, struct CSliceRef_VtopRange addrs, VirtualTranslationCallback out, VirtualTranslationFailCallback out_fail)  {
 (((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_virtualtranslate)->virt_to_phys_list(&((struct IntoProcessInstance_CBox_c_void_____CArc_c_void *)self)->container, addrs, out, out_fail);
 
 }
@@ -2872,13 +3100,13 @@ static inline void mf_intoprocessinstance_virt_page_map(void *self, imem gap_siz
 
 }
 
-static inline int32_t mf_connectorinstance_phys_read_raw_iter(void *self, struct CIterator_PhysicalReadData data, ReadFailCallback * out_fail)  {
-    int32_t __ret = (((struct ConnectorInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_physicalmemory)->phys_read_raw_iter(&((struct ConnectorInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_connectorinstance_phys_read_raw_iter(void *self, PhysicalReadMemOps data)  {
+    int32_t __ret = (((struct ConnectorInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_physicalmemory)->phys_read_raw_iter(&((struct ConnectorInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 
-static inline int32_t mf_connectorinstance_phys_write_raw_iter(void *self, struct CIterator_PhysicalWriteData data, WriteFailCallback * out_fail)  {
-    int32_t __ret = (((struct ConnectorInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_physicalmemory)->phys_write_raw_iter(&((struct ConnectorInstance_CBox_c_void_____CArc_c_void *)self)->container, data, out_fail);
+static inline int32_t mf_connectorinstance_phys_write_raw_iter(void *self, PhysicalWriteMemOps data)  {
+    int32_t __ret = (((struct ConnectorInstance_CBox_c_void_____CArc_c_void *)self)->vtbl_physicalmemory)->phys_write_raw_iter(&((struct ConnectorInstance_CBox_c_void_____CArc_c_void *)self)->container, data);
     return __ret;
 }
 

--- a/memflow-ffi/src/os/mod.rs
+++ b/memflow-ffi/src/os/mod.rs
@@ -1,8 +1,4 @@
 #[allow(unused)]
-pub use memflow::mem::phys_mem::*;
-#[allow(unused)]
-pub use memflow::mem::virt_mem::*;
-#[allow(unused)]
 pub use memflow::os::*;
 #[allow(unused)]
 pub use memflow::plugins::*;

--- a/memflow-ffi/verify_headers.sh
+++ b/memflow-ffi/verify_headers.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+DIFFC=$(diff memflow.h <(rustup run nightly cglue-bindgen +nightly -c cglue.toml -- --config cbindgen.toml --crate memflow-ffi -l C))
+DIFFCPP=$(diff memflow.hpp <(rustup run nightly cglue-bindgen +nightly -c cglue.toml -- --config cbindgen.toml --crate memflow-ffi -l C++))
+if [ "$DIFFC" != "" ] || [ "$DIFFCPP" != "" ]
+then
+	exit 1
+fi

--- a/memflow/Cargo.toml
+++ b/memflow/Cargo.toml
@@ -30,10 +30,10 @@ bumpalo = { version = "^3.9.1", features = ["collections"] }
 no-std-compat = { version = "^0.4.1", features = ["alloc"] }
 itertools = { version = "^0.10.3", default-features = false }
 memmap = { version = "^0.7.0", optional = true }
-hashbrown = "^0.11.2"
+hashbrown = "^0.12"
 fixed-slice-vec = "^0.8.0"
 cglue = { version = ">=0.2.8", default-features = false }
-rangemap = "^0.1.14"
+rangemap = "^1.0"
 
 # plugins
 libloading = { version = "^0.7.2", optional = true }

--- a/memflow/Cargo.toml
+++ b/memflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memflow"
-version = "0.2.0-beta1"
+version = "0.2.0-beta2"
 authors = ["ko1N <ko1N1337@gmail.com>", "Aurimas Blažulionis <0x60@pm.me>"]
 edition = "2018"
 description = "core components of the memflow physical memory introspection framework"
@@ -8,7 +8,6 @@ documentation = "https://docs.rs/memflow"
 readme = "../README.md"
 homepage = "https://memflow.github.io"
 repository = "https://github.com/memflow/memflow"
-license-file = "../LICENSE"
 license = "MIT"
 keywords = [ "memflow", "introspection", "memory", "dma" ]
 categories = [ "memory-management", "os" ]
@@ -33,7 +32,7 @@ itertools = { version = "^0.10.3", default-features = false }
 memmap = { version = "^0.7.0", optional = true }
 hashbrown = "^0.11.2"
 fixed-slice-vec = "^0.8.0"
-cglue = { version = ">=0.2.5", default-features = false }
+cglue = { version = ">=0.2.8", default-features = false }
 rangemap = "^0.1.14"
 
 # plugins

--- a/memflow/examples/integration.rs
+++ b/memflow/examples/integration.rs
@@ -107,7 +107,7 @@ fn kernel_modules(kernel: &mut impl Os) -> Result<Vec<ModuleInfo>> {
 }
 
 fn parse_args() -> ArgMatches {
-    App::new("integration example")
+    Command::new("integration example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/examples/kernel_modules.rs
+++ b/memflow/examples/kernel_modules.rs
@@ -1,4 +1,4 @@
-use clap::{crate_authors, crate_version, App, Arg, ArgMatches};
+use clap::{crate_authors, crate_version, Arg, ArgMatches, Command};
 use log::Level;
 /// A simple kernel module list example using memflow
 use memflow::prelude::v1::*;
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
 }
 
 fn parse_args() -> ArgMatches {
-    App::new("kernel_modules example")
+    Command::new("kernel_modules example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/examples/keyboard.rs
+++ b/memflow/examples/keyboard.rs
@@ -1,4 +1,4 @@
-use clap::{crate_authors, crate_version, App, Arg, ArgMatches};
+use clap::{crate_authors, crate_version, Arg, ArgMatches, Command};
 use log::Level;
 /// A simple keyboard example using memflow
 use memflow::prelude::v1::*;
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
 }
 
 fn parse_args() -> ArgMatches {
-    App::new("keyboard example")
+    Command::new("keyboard example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/examples/module_list.rs
+++ b/memflow/examples/module_list.rs
@@ -1,4 +1,4 @@
-use clap::{crate_authors, crate_version, App, Arg, ArgMatches};
+use clap::{crate_authors, crate_version, Arg, ArgMatches, Command};
 use log::Level;
 /// A simple process list example using memflow
 use memflow::prelude::v1::*;
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
 }
 
 fn parse_args() -> ArgMatches {
-    App::new("module_list example")
+    Command::new("module_list example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/examples/multithreading.rs
+++ b/memflow/examples/multithreading.rs
@@ -92,7 +92,7 @@ pub fn main() {
 }
 
 fn parse_args() -> Result<(String, ConnectorArgs, String, OsArgs, log::Level)> {
-    let matches = App::new("multithreading example")
+    let matches = Command::new("multithreading example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/examples/open_process.rs
+++ b/memflow/examples/open_process.rs
@@ -1,4 +1,4 @@
-use clap::{crate_authors, crate_version, App, Arg, ArgMatches};
+use clap::{crate_authors, crate_version, Arg, ArgMatches, Command};
 use log::Level;
 /// A simple process list example using memflow
 use memflow::prelude::v1::*;
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
 }
 
 fn parse_args() -> ArgMatches {
-    App::new("open_process example")
+    Command::new("open_process example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/examples/process_list.rs
+++ b/memflow/examples/process_list.rs
@@ -1,4 +1,4 @@
-use clap::{crate_authors, crate_version, App, Arg, ArgMatches};
+use clap::{crate_authors, crate_version, Arg, ArgMatches, Command};
 use log::Level;
 /// A simple process list example using memflow
 use memflow::prelude::v1::*;
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
 }
 
 fn parse_args() -> ArgMatches {
-    App::new("mfps example")
+    Command::new("mfps example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/examples/read_bench.rs
+++ b/memflow/examples/read_bench.rs
@@ -155,7 +155,7 @@ fn main() -> Result<()> {
 }
 
 fn parse_args() -> ArgMatches {
-    App::new("read_bench example")
+    Command::new("read_bench example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/examples/read_bench.rs
+++ b/memflow/examples/read_bench.rs
@@ -115,8 +115,8 @@ fn read_bench(mut kernel: OsInstanceArcBox) -> Result<()> {
 
             println!("Mapped memory map (with up to 1GB gaps):");
 
-            for MemData(address, size) in mem_map {
-                println!("{:x}-{:x}", address, address + size);
+            for MemData3(address, size, pt) in mem_map {
+                println!("{:x}-{:x} {:?}", address, address + size, pt);
             }
 
             rwtest(

--- a/memflow/examples/target_list.rs
+++ b/memflow/examples/target_list.rs
@@ -25,7 +25,7 @@ fn main() {
 }
 
 fn parse_args() -> String {
-    let matches = App::new("multithreading example")
+    let matches = Command::new("multithreading example")
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::new("verbose").short('v').multiple_occurrences(true))

--- a/memflow/src/architecture/arm/mod.rs
+++ b/memflow/src/architecture/arm/mod.rs
@@ -12,7 +12,7 @@ use crate::mem::virt_translate::{
 
 use crate::error::{Error, ErrorKind, ErrorOrigin, Result};
 use crate::iter::SplitAtIndex;
-use crate::mem::{MemData, PhysicalMemory};
+use crate::mem::{MemData3, PhysicalMemory};
 use crate::types::{size, umem, Address};
 
 pub struct ArmArchitecture {
@@ -92,7 +92,7 @@ impl MmuTranslationBase for ArmPageTableBase {
     fn virt_addr_filter<B>(
         &self,
         spec: &ArchMmuSpec,
-        addr: MemData<Address, B>,
+        addr: MemData3<Address, Address, B>,
         work_group: (&mut TranslationChunk<Self>, &mut TranslateDataVec<B>),
         out_fail: &mut VtopFailureCallback<B>,
     ) where
@@ -106,7 +106,7 @@ impl VirtualTranslate3 for ArmVirtualTranslate {
     fn virt_to_phys_iter<
         T: PhysicalMemory + ?Sized,
         B: SplitAtIndex,
-        VI: Iterator<Item = MemData<Address, B>>,
+        VI: Iterator<Item = MemData3<Address, Address, B>>,
     >(
         &self,
         mem: &mut T,

--- a/memflow/src/architecture/x86/mod.rs
+++ b/memflow/src/architecture/x86/mod.rs
@@ -10,7 +10,7 @@ use crate::mem::virt_translate::{
 
 use crate::error::{Error, ErrorKind, ErrorOrigin, Result};
 use crate::iter::SplitAtIndex;
-use crate::mem::{MemData, PhysicalMemory};
+use crate::mem::{MemData3, PhysicalMemory};
 use crate::types::{umem, Address};
 
 use std::ptr;
@@ -67,7 +67,7 @@ impl VirtualTranslate3 for X86VirtualTranslate {
     fn virt_to_phys_iter<
         T: PhysicalMemory + ?Sized,
         B: SplitAtIndex,
-        VI: Iterator<Item = MemData<Address, B>>,
+        VI: Iterator<Item = MemData3<Address, Address, B>>,
     >(
         &self,
         mem: &mut T,

--- a/memflow/src/connector/fileio.rs
+++ b/memflow/src/connector/fileio.rs
@@ -129,6 +129,9 @@ impl<T: Seek + Read + Write + Send> FileIoMemory<T> {
     }
 }
 
+#[allow(clippy::needless_option_as_deref)]
+#[allow(clippy::collapsible_if)]
+#[allow(clippy::blocks_in_if_conditions)]
 impl<T: Seek + Read + Write + Send> PhysicalMemory for FileIoMemory<T> {
     fn phys_read_raw_iter(&mut self, mut data: PhysicalReadMemOps) -> Result<()> {
         let mut iter = self.mem_map.map_iter(data.inp, data.out_fail);

--- a/memflow/src/connector/mmap.rs
+++ b/memflow/src/connector/mmap.rs
@@ -90,6 +90,7 @@ impl<T: AsRef<[u8]>, F: AsRef<MemoryMap<T>>> MappedPhysicalMemory<T, F> {
     }
 }
 
+#[allow(clippy::needless_option_as_deref)]
 impl<'a, F: AsRef<MemoryMap<&'a mut [u8]>> + Send> PhysicalMemory
     for MappedPhysicalMemory<&'a mut [u8], F>
 {
@@ -137,6 +138,7 @@ impl<'a, F: AsRef<MemoryMap<&'a mut [u8]>> + Send> PhysicalMemory
     }
 }
 
+#[allow(clippy::needless_option_as_deref)]
 impl<'a, F: AsRef<MemoryMap<&'a [u8]>> + Send> PhysicalMemory
     for MappedPhysicalMemory<&'a [u8], F>
 {

--- a/memflow/src/dummy/mem.rs
+++ b/memflow/src/dummy/mem.rs
@@ -3,10 +3,7 @@ use crate::connector::MappedPhysicalMemory;
 use crate::derive::connector;
 use crate::error::{Error, ErrorKind, ErrorOrigin, Result};
 use crate::mem::mem_data::*;
-use crate::mem::{
-    MemoryMap, PhysicalMemory, PhysicalMemoryMapping, PhysicalMemoryMetadata, ReadFailCallback,
-    WriteFailCallback,
-};
+use crate::mem::{MemoryMap, PhysicalMemory, PhysicalMemoryMapping, PhysicalMemoryMetadata};
 use crate::plugins::*;
 use crate::types::{size, umem, Address};
 
@@ -54,21 +51,13 @@ impl Clone for DummyMemory {
 
 impl PhysicalMemory for DummyMemory {
     #[inline]
-    fn phys_read_raw_iter<'a>(
-        &mut self,
-        data: CIterator<PhysicalReadData<'a>>,
-        out_fail: &mut ReadFailCallback<'_, 'a>,
-    ) -> Result<()> {
-        self.mem.phys_read_raw_iter(data, out_fail)
+    fn phys_read_raw_iter(&mut self, data: PhysicalReadMemOps) -> Result<()> {
+        self.mem.phys_read_raw_iter(data)
     }
 
     #[inline]
-    fn phys_write_raw_iter<'a>(
-        &mut self,
-        data: CIterator<PhysicalWriteData<'a>>,
-        out_fail: &mut WriteFailCallback<'_, 'a>,
-    ) -> Result<()> {
-        self.mem.phys_write_raw_iter(data, out_fail)
+    fn phys_write_raw_iter(&mut self, data: PhysicalWriteMemOps) -> Result<()> {
+        self.mem.phys_write_raw_iter(data)
     }
 
     #[inline]

--- a/memflow/src/dummy/os.rs
+++ b/memflow/src/dummy/os.rs
@@ -511,21 +511,13 @@ impl<'a> OsInner<'a> for DummyOs {
 
 impl PhysicalMemory for DummyOs {
     #[inline]
-    fn phys_read_raw_iter<'a>(
-        &mut self,
-        data: CIterator<PhysicalReadData<'a>>,
-        out_fail: &mut ReadFailCallback<'_, 'a>,
-    ) -> Result<()> {
-        self.mem.phys_read_raw_iter(data, out_fail)
+    fn phys_read_raw_iter(&mut self, data: PhysicalReadMemOps) -> Result<()> {
+        self.mem.phys_read_raw_iter(data)
     }
 
     #[inline]
-    fn phys_write_raw_iter<'a>(
-        &mut self,
-        data: CIterator<PhysicalWriteData<'a>>,
-        out_fail: &mut WriteFailCallback<'_, 'a>,
-    ) -> Result<()> {
-        self.mem.phys_write_raw_iter(data, out_fail)
+    fn phys_write_raw_iter(&mut self, data: PhysicalWriteMemOps) -> Result<()> {
+        self.mem.phys_write_raw_iter(data)
     }
 
     #[inline]

--- a/memflow/src/mem/mem_data.rs
+++ b/memflow/src/mem/mem_data.rs
@@ -1,8 +1,9 @@
 //! Generic address and buffer association structure.
 
 use crate::iter::SplitAtIndex;
-use crate::types::{umem, Address, PhysicalAddress};
-use cglue::callback::OpaqueCallback;
+use crate::types::{umem, Address, PageType, PhysicalAddress};
+use cglue::callback::{Callbackable, OpaqueCallback};
+use cglue::iter::CIterator;
 
 use cglue::slice::*;
 
@@ -14,28 +15,28 @@ use cglue::slice::*;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 #[cfg_attr(feature = "abi_stable", derive(::abi_stable::StableAbi))]
-pub struct MemData<A, T>(pub A, pub T);
+pub struct MemData2<A, T>(pub A, pub T);
 
-impl<A, T> From<MemData<A, T>> for (A, T) {
-    fn from(MemData(a, b): MemData<A, T>) -> Self {
+impl<A, T> From<MemData2<A, T>> for (A, T) {
+    fn from(MemData2(a, b): MemData2<A, T>) -> Self {
         (a, b)
     }
 }
 
-impl<A, T> From<(A, T)> for MemData<A, T> {
+impl<A, T> From<(A, T)> for MemData2<A, T> {
     fn from((a, b): (A, T)) -> Self {
-        MemData(a, b)
+        MemData2(a, b)
     }
 }
 
-impl<T: SplitAtIndex> SplitAtIndex for MemData<Address, T> {
+impl<T: SplitAtIndex> SplitAtIndex for MemData2<Address, T> {
     fn split_at(self, idx: umem) -> (Option<Self>, Option<Self>) {
         let (left, right) = self.1.split_at(idx);
 
         if let Some(left) = left {
             let left_len = left.length();
             (
-                Some(MemData(self.0, left)),
+                Some(MemData2(self.0, left)),
                 Some(self.0 + left_len).zip(right).map(<_>::into),
             )
         } else {
@@ -49,7 +50,7 @@ impl<T: SplitAtIndex> SplitAtIndex for MemData<Address, T> {
         if let Some(left) = left {
             let left_len = left.length();
             (
-                Some(MemData(self.0, left)),
+                Some(MemData2(self.0, left)),
                 Some(self.0 + left_len).zip(right).map(<_>::into),
             )
         } else {
@@ -66,34 +67,207 @@ impl<T: SplitAtIndex> SplitAtIndex for MemData<Address, T> {
     }
 }
 
+/// Generic type representing an address, original address,and associated data.
+///
+/// This base type is always used for initialization, but the commonly used type aliases are:
+/// `ReadDataIn`, `WriteDataIn`, `PhysicalReadDataIn`, and `PhysicalWriteDataIn`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "abi_stable", derive(::abi_stable::StableAbi))]
+pub struct MemData3<A, M, T>(pub A, pub M, pub T);
+
+impl<A, M, T> From<MemData3<A, M, T>> for (A, M, T) {
+    fn from(MemData3(a, b, c): MemData3<A, M, T>) -> Self {
+        (a, b, c)
+    }
+}
+
+impl<A, M, T> From<(A, M, T)> for MemData3<A, M, T> {
+    fn from((a, b, c): (A, M, T)) -> Self {
+        MemData3(a, b, c)
+    }
+}
+
+impl<T: SplitAtIndex> SplitAtIndex for MemData3<Address, Address, T> {
+    fn split_at(self, idx: umem) -> (Option<Self>, Option<Self>) {
+        let (left, right) = self.2.split_at(idx);
+
+        let meta = self.1;
+
+        if let Some(left) = left {
+            let left_len = left.length();
+            (
+                Some(MemData3(self.0, meta, left)),
+                Some(self.0 + left_len)
+                    .zip(right)
+                    .map(|(a, b)| (a, meta + left_len, b))
+                    .map(<_>::into),
+            )
+        } else {
+            (
+                None,
+                Some(self.0)
+                    .zip(right)
+                    .map(|(a, b)| (a, meta, b))
+                    .map(<_>::into),
+            )
+        }
+    }
+
+    unsafe fn split_at_mut(&mut self, idx: umem) -> (Option<Self>, Option<Self>) {
+        let (left, right) = self.2.split_at_mut(idx);
+
+        let meta = self.1;
+
+        if let Some(left) = left {
+            let left_len = left.length();
+            (
+                Some(MemData3(self.0, meta, left)),
+                Some(self.0 + left_len)
+                    .zip(right)
+                    .map(|(a, b)| (a, meta + left_len, b))
+                    .map(<_>::into),
+            )
+        } else {
+            (
+                None,
+                Some(self.0)
+                    .zip(right)
+                    .map(|(a, b)| (a, meta, b))
+                    .map(<_>::into),
+            )
+        }
+    }
+
+    fn length(&self) -> umem {
+        self.2.length()
+    }
+
+    fn size_hint(&self) -> usize {
+        self.2.size_hint()
+    }
+}
+
 /// MemData type for regular memory reads.
-pub type ReadData<'a> = MemData<Address, CSliceMut<'a, u8>>;
+pub type ReadDataRaw<'a> = MemData3<Address, Address, CSliceMut<'a, u8>>;
+pub type ReadData<'a> = MemData2<Address, CSliceMut<'a, u8>>;
+
+pub trait ReadRawIterator<'a>: Iterator<Item = ReadDataRaw<'a>> + 'a {}
+impl<'a, T: Iterator<Item = ReadDataRaw<'a>> + 'a> ReadRawIterator<'a> for T {}
 
 pub trait ReadIterator<'a>: Iterator<Item = ReadData<'a>> + 'a {}
 impl<'a, T: Iterator<Item = ReadData<'a>> + 'a> ReadIterator<'a> for T {}
 
 /// MemData type for regular memory writes.
-pub type WriteData<'a> = MemData<Address, CSliceRef<'a, u8>>;
+pub type WriteDataRaw<'a> = MemData3<Address, Address, CSliceRef<'a, u8>>;
+pub type WriteData<'a> = MemData2<Address, CSliceRef<'a, u8>>;
 
-pub type MemoryRange = MemData<Address, umem>;
+pub type VtopRange = MemData2<Address, umem>;
+
+pub type MemoryRange = MemData3<Address, umem, PageType>;
+
+pub trait WriteRawIterator<'a>: Iterator<Item = WriteDataRaw<'a>> + 'a {}
+impl<'a, T: Iterator<Item = WriteDataRaw<'a>> + 'a> WriteRawIterator<'a> for T {}
 
 pub trait WriteIterator<'a>: Iterator<Item = WriteData<'a>> + 'a {}
 impl<'a, T: Iterator<Item = WriteData<'a>> + 'a> WriteIterator<'a> for T {}
 
 /// MemData type for physical memory reads.
-pub type PhysicalReadData<'a> = MemData<PhysicalAddress, CSliceMut<'a, u8>>;
+pub type PhysicalReadData<'a> = MemData3<PhysicalAddress, Address, CSliceMut<'a, u8>>;
 
 pub trait PhysicalReadIterator<'a>: Iterator<Item = PhysicalReadData<'a>> + 'a {}
 impl<'a, T: Iterator<Item = PhysicalReadData<'a>> + 'a> PhysicalReadIterator<'a> for T {}
 
 /// MemData type for physical memory writes.
-pub type PhysicalWriteData<'a> = MemData<PhysicalAddress, CSliceRef<'a, u8>>;
+pub type PhysicalWriteData<'a> = MemData3<PhysicalAddress, Address, CSliceRef<'a, u8>>;
 
 pub trait PhysicalWriteIterator<'a>: Iterator<Item = PhysicalWriteData<'a>> + 'a {}
 impl<'a, T: Iterator<Item = PhysicalWriteData<'a>> + 'a> PhysicalWriteIterator<'a> for T {}
 
-pub type ReadFailCallback<'a, 'b> = OpaqueCallback<'a, ReadData<'b>>;
+pub type ReadFailCallback<'a, 'b> = OpaqueCallback<'a, ReadDataRaw<'b>>;
+pub type ReadCallback<'a, 'b> = OpaqueCallback<'a, ReadData<'b>>;
 
-pub type WriteFailCallback<'a, 'b> = OpaqueCallback<'a, WriteData<'b>>;
+pub type WriteFailCallback<'a, 'b> = OpaqueCallback<'a, WriteDataRaw<'b>>;
+pub type WriteCallback<'a, 'b> = OpaqueCallback<'a, WriteData<'b>>;
 
 pub type MemoryRangeCallback<'a> = OpaqueCallback<'a, MemoryRange>;
+
+/// Data needed to perform memory operations.
+///
+/// `inp` is an iterator containing
+#[repr(C)]
+#[cfg_attr(feature = "abi_stable", derive(::abi_stable::StableAbi))]
+pub struct MemOps<'a: 'c, 'b, 'c, T: 'b, P: 'a> {
+    pub inp: CIterator<'b, T>,
+    pub out: Option<&'c mut OpaqueCallback<'a, P>>,
+    pub out_fail: Option<&'c mut OpaqueCallback<'a, P>>,
+}
+
+impl<'a: 'c, 'b, 'c, T: 'b, P: 'a> MemOps<'a, 'b, 'c, T, P> {
+    #[inline(always)]
+    pub fn with_raw_mut<O, F: FnOnce(MemOps<T, P>) -> O>(
+        iter: impl Into<CIterator<'b, T>>,
+        out: Option<&'c mut OpaqueCallback<'a, P>>,
+        out_fail: Option<&'c mut OpaqueCallback<'a, P>>,
+        func: F,
+    ) -> O {
+        func(Self {
+            inp: iter.into(),
+            out,
+            out_fail,
+        })
+    }
+
+    #[inline(always)]
+    pub fn with_raw<O, F: FnOnce(MemOps<T, P>) -> O>(
+        mut iter: impl Iterator<Item = T>,
+        out: Option<&mut OpaqueCallback<'a, P>>,
+        out_fail: Option<&mut OpaqueCallback<'a, P>>,
+        func: F,
+    ) -> O {
+        func(MemOps {
+            inp: (&mut iter).into(),
+            out,
+            out_fail,
+        })
+    }
+}
+
+impl<'a: 'c, 'b, 'c, A: 'b + Into<Address> + Copy, T: 'b, P: 'a>
+    MemOps<'a, 'b, 'c, MemData3<A, Address, T>, P>
+{
+    #[inline(always)]
+    pub fn with<O, F: FnOnce(MemOps<MemData3<A, Address, T>, P>) -> O>(
+        iter: impl Iterator<Item = (A, T)> + 'a,
+        out: Option<&'c mut OpaqueCallback<'a, P>>,
+        out_fail: Option<&'c mut OpaqueCallback<'a, P>>,
+        func: F,
+    ) -> O {
+        let iter = iter.map(|(a, b)| MemData3(a, a.into(), b));
+        Self::with_raw(iter, out, out_fail, func)
+    }
+}
+
+impl<'a: 'c, 'b, 'c, T: 'b, I: Into<CIterator<'b, T>>, P: 'a> From<I> for MemOps<'a, 'b, 'c, T, P> {
+    fn from(inp: I) -> Self {
+        Self {
+            inp: inp.into(),
+            out: None,
+            out_fail: None,
+        }
+    }
+}
+
+pub fn opt_call<T>(cb: Option<&mut impl Callbackable<T>>, data: T) -> bool {
+    cb.map(|cb| cb.call(data)).unwrap_or(true)
+}
+
+pub type ReadRawMemOps<'buf, 'a, 'b, 'c> = MemOps<'a, 'b, 'c, ReadDataRaw<'buf>, ReadData<'buf>>;
+pub type WriteRawMemOps<'buf, 'a, 'b, 'c> = MemOps<'a, 'b, 'c, WriteDataRaw<'buf>, WriteData<'buf>>;
+pub type ReadMemOps<'buf, 'a, 'b, 'c> = MemOps<'a, 'b, 'c, ReadData<'buf>, ReadData<'buf>>;
+pub type WriteMemOps<'buf, 'a, 'b, 'c> = MemOps<'a, 'b, 'c, WriteData<'buf>, WriteData<'buf>>;
+pub type PhysicalReadMemOps<'buf, 'a, 'b, 'c> =
+    MemOps<'a, 'b, 'c, PhysicalReadData<'buf>, ReadData<'buf>>;
+pub type PhysicalWriteMemOps<'buf, 'a, 'b, 'c> =
+    MemOps<'a, 'b, 'c, PhysicalWriteData<'buf>, WriteData<'buf>>;

--- a/memflow/src/mem/mem_map.rs
+++ b/memflow/src/mem/mem_map.rs
@@ -401,6 +401,7 @@ pub struct MemoryMapIterator<'a, I, M, T, C> {
     cur_map_pos: usize,
 }
 
+#[allow(clippy::needless_option_as_deref)]
 impl<
         'a,
         I: Iterator<Item = MemData3<Address, Address, T>>,

--- a/memflow/src/mem/memory_view/arch_overlay.rs
+++ b/memflow/src/mem/memory_view/arch_overlay.rs
@@ -35,20 +35,12 @@ impl<T: MemoryView> ArchOverlayView<T> {
 }
 
 impl<T: MemoryView> MemoryView for ArchOverlayView<T> {
-    fn read_raw_iter<'a>(
-        &mut self,
-        data: CIterator<ReadData<'a>>,
-        out_fail: &mut ReadFailCallback<'_, 'a>,
-    ) -> Result<()> {
-        self.mem.read_raw_iter(data, out_fail)
+    fn read_raw_iter(&mut self, data: ReadRawMemOps) -> Result<()> {
+        self.mem.read_raw_iter(data)
     }
 
-    fn write_raw_iter<'a>(
-        &mut self,
-        data: CIterator<WriteData<'a>>,
-        out_fail: &mut WriteFailCallback<'_, 'a>,
-    ) -> Result<()> {
-        self.mem.write_raw_iter(data, out_fail)
+    fn write_raw_iter(&mut self, data: WriteRawMemOps) -> Result<()> {
+        self.mem.write_raw_iter(data)
     }
 
     fn metadata(&self) -> MemoryViewMetadata {

--- a/memflow/src/mem/memory_view/batcher.rs
+++ b/memflow/src/mem/memory_view/batcher.rs
@@ -51,7 +51,7 @@ impl<'a, T: MemoryView> MemoryViewBatcher<'a, T> {
 
     // read helpers
     pub fn read_raw_into<'b: 'a>(&mut self, addr: Address, out: &'b mut [u8]) -> &mut Self {
-        self.read_raw_iter(Some(MemData(addr, out.into())).into_iter())
+        self.read_raw_iter(std::iter::once(MemData2(addr, out.into())).into_iter())
     }
 
     pub fn read_into<'b: 'a, F: Pod + ?Sized>(
@@ -64,7 +64,7 @@ impl<'a, T: MemoryView> MemoryViewBatcher<'a, T> {
 
     // write helpers
     pub fn write_raw_into<'b: 'a>(&mut self, addr: Address, out: &'b [u8]) -> &mut Self {
-        self.write_raw_iter(Some(MemData(addr, out.into())).into_iter())
+        self.write_raw_iter(std::iter::once(MemData2(addr, out.into())).into_iter())
     }
 
     pub fn write_into<'b: 'a, F: Pod + ?Sized>(&mut self, addr: Address, out: &'b F) -> &mut Self {

--- a/memflow/src/mem/memory_view/mod.rs
+++ b/memflow/src/mem/memory_view/mod.rs
@@ -63,12 +63,84 @@ pub trait MemoryView: Send {
 
     // Read helpers
 
+    /// Read arbitrary amount of data.
+    ///
+    /// # Arguments
+    ///
+    /// * `inp` - input iterator of (address, buffer) pairs.
+    /// * `out` - optional callback for any successful reads - along the way `inp` pairs may be
+    /// split and only parts of the reads may succeed. This callback will return any successful
+    /// chunks that have their buffers filled in.
+    /// * `out_fail` - optional callback for any unsuccessful reads - this is the opposite of
+    /// `out`, meaning any unsuccessful chunks with buffers in an unspecified state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use memflow::types::Address;
+    /// use memflow::mem::{MemoryView, MemData2};
+    ///
+    /// fn read(mut mem: impl MemoryView, read_addrs: &[Address]) {
+    ///
+    ///     let mut bufs = vec![0u8; 8 * read_addrs.len()];
+    ///
+    ///     let data = read_addrs
+    ///         .iter()
+    ///         .zip(bufs.chunks_mut(8))
+    ///         .map(|(&a, chunk)| MemData2(a, chunk.into()));
+    ///
+    ///     mem.read_iter(data, None, None).unwrap();
+    ///
+    ///     println!("{:?}", bufs);
+    ///
+    ///     # assert!(!bufs.chunks_exact(2).inspect(|c| println!("{:?}", c)).any(|c| c != &[255, 0]));
+    /// }
+    /// # use memflow::dummy::DummyOs;
+    /// # use memflow::types::size;
+    /// # use memflow::os::Process;
+    /// # let proc = DummyOs::quick_process(
+    /// #     size::mb(2),
+    /// #     &[255, 0].iter().cycle().copied().take(32).collect::<Vec<u8>>()
+    /// # );
+    /// # let virt_base = proc.info().address;
+    /// # read(proc, &[virt_base, virt_base + 16usize]);
+    /// ```
     #[int_result]
-    fn read_iter(&mut self, data: ReadMemOps) -> Result<()> {
+    #[vtbl_only]
+    #[custom_impl(
+        // Types within the C interface other than self and additional wrappers.
+        {
+            inp: CIterator<ReadData<'a>>,
+            out: Option<&mut ReadCallback<'b, 'a>>,
+            out_fail: Option<&mut ReadCallback<'b, 'a>>,
+        },
+        // Unwrapped return type
+        Result<()>,
+        // Conversion in trait impl to C arguments (signature names are expected).
+        {},
+        // This is the body of C impl minus the automatic wrapping.
+        {
+            MemOps::with_raw(
+                inp.map(|MemData2(a, b)| MemData3(a, a, b)),
+                out,
+                out_fail,
+                |data| this.read_raw_iter(data),
+            )
+        },
+        // This part is processed in the trait impl after the call returns (impl_func_ret,
+        // nothing extra needs to happen here).
+        {},
+    )]
+    fn read_iter<'a, 'b>(
+        &mut self,
+        inp: impl Iterator<Item = ReadData<'a>>,
+        out: Option<&mut ReadCallback<'b, 'a>>,
+        out_fail: Option<&mut ReadCallback<'b, 'a>>,
+    ) -> Result<()> {
         MemOps::with_raw(
-            data.inp.map(|MemData2(a, b)| MemData3(a, a, b)),
-            data.out,
-            data.out_fail,
+            inp.map(|MemData2(a, b)| MemData3(a, a, b)),
+            out,
+            out_fail,
             |data| self.read_raw_iter(data),
         )
     }
@@ -184,12 +256,81 @@ pub trait MemoryView: Send {
 
     // Write helpers
 
+    /// Write arbitrary amount of data.
+    ///
+    /// # Arguments
+    ///
+    /// * `inp` - input iterator of (address, buffer) pairs.
+    /// * `out` - optional callback for any successful writes - along the way `inp` pairs may be
+    /// split and only parts of the writes may succeed. This callback will return any successful
+    /// chunks that have their buffers filled in.
+    /// * `out_fail` - optional callback for any unsuccessful writes - this is the opposite of
+    /// `out`, meaning any unsuccessful chunks with buffers in an unspecified state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use memflow::types::Address;
+    /// use memflow::mem::{MemoryView, MemData2};
+    /// use dataview::Pod;
+    ///
+    /// fn write(mut mem: impl MemoryView, writes: &[(Address, usize)]) {
+    ///
+    ///     let data = writes
+    ///         .iter()
+    ///         .map(|(a, chunk)| MemData2(*a, chunk.as_bytes().into()));
+    ///
+    ///     mem.write_iter(data, None, None).unwrap();
+    ///
+    ///     # assert_eq!(mem.read::<usize>(writes[0].0), Ok(3));
+    ///     # assert_eq!(mem.read::<usize>(writes[1].0), Ok(4));
+    /// }
+    /// # use memflow::dummy::DummyOs;
+    /// # use memflow::types::size;
+    /// # use memflow::os::Process;
+    /// # let proc = DummyOs::quick_process(
+    /// #     size::mb(2),
+    /// #     &[255, 0].iter().cycle().copied().take(32).collect::<Vec<u8>>()
+    /// # );
+    /// # let virt_base = proc.info().address;
+    /// # write(proc, &[(virt_base, 3), (virt_base + 16usize, 4)]);
+    /// ```
     #[int_result]
-    fn write_iter(&mut self, data: WriteMemOps) -> Result<()> {
+    #[vtbl_only]
+    #[custom_impl(
+        // Types within the C interface other than self and additional wrappers.
+        {
+            inp: CIterator<WriteData<'a>>,
+            out: Option<&mut WriteCallback<'b, 'a>>,
+            out_fail: Option<&mut WriteCallback<'b, 'a>>,
+        },
+        // Unwrapped return type
+        Result<()>,
+        // Conversion in trait impl to C arguments (signature names are expected).
+        {},
+        // This is the body of C impl minus the automatic wrapping.
+        {
+            MemOps::with_raw(
+                inp.map(|MemData2(a, b)| MemData3(a, a, b)),
+                out,
+                out_fail,
+                |data| this.write_raw_iter(data),
+            )
+        },
+        // This part is processed in the trait impl after the call returns (impl_func_ret,
+        // nothing extra needs to happen here).
+        {},
+    )]
+    fn write_iter<'a, 'b>(
+        &mut self,
+        inp: impl Iterator<Item = WriteData<'a>>,
+        out: Option<&mut WriteCallback<'b, 'a>>,
+        out_fail: Option<&mut WriteCallback<'b, 'a>>,
+    ) -> Result<()> {
         MemOps::with_raw(
-            data.inp.map(|MemData2(a, b)| MemData3(a, a, b)),
-            data.out,
-            data.out_fail,
+            inp.map(|MemData2(a, b)| MemData3(a, a, b)),
+            out,
+            out_fail,
             |data| self.write_raw_iter(data),
         )
     }
@@ -205,7 +346,7 @@ pub trait MemoryView: Send {
         let iter = data.iter().copied();
 
         MemOps::with_raw(iter, None, Some(&mut callback.into()), |data| {
-            self.write_iter(data)
+            self.write_iter(data.inp, data.out, data.out_fail)
         })?;
 
         out

--- a/memflow/src/mem/memory_view/remap_view.rs
+++ b/memflow/src/mem/memory_view/remap_view.rs
@@ -21,7 +21,7 @@ impl<T: MemoryView> RemapView<T> {
 
 impl<T: MemoryView> MemoryView for RemapView<T> {
     fn read_raw_iter(&mut self, MemOps { inp, out_fail, out }: ReadRawMemOps) -> Result<()> {
-        let out_fail = out_fail.map(|of| std::cell::RefCell::new(of));
+        let out_fail = out_fail.map(std::cell::RefCell::new);
 
         let mut out_fail1 = out_fail
             .as_ref()
@@ -47,7 +47,7 @@ impl<T: MemoryView> MemoryView for RemapView<T> {
     }
 
     fn write_raw_iter(&mut self, MemOps { inp, out_fail, out }: WriteRawMemOps) -> Result<()> {
-        let out_fail = out_fail.map(|of| std::cell::RefCell::new(of));
+        let out_fail = out_fail.map(std::cell::RefCell::new);
 
         let mut out_fail1 = out_fail
             .as_ref()

--- a/memflow/src/mem/phys_mem/cache/page_cache.rs
+++ b/memflow/src/mem/phys_mem/cache/page_cache.rs
@@ -40,6 +40,7 @@ pub struct PageCache<'a, T> {
 
 unsafe impl<'a, T> Send for PageCache<'a, T> {}
 
+#[allow(clippy::needless_option_as_deref)]
 impl<'a, T: CacheValidator> PageCache<'a, T> {
     pub fn new(arch: ArchitectureObj, size: usize, page_type_mask: PageType, validator: T) -> Self {
         Self::with_page_size(arch.page_size(), size, page_type_mask, validator)

--- a/memflow/src/mem/virt_mem/virtual_dma.rs
+++ b/memflow/src/mem/virt_mem/virtual_dma.rs
@@ -186,6 +186,7 @@ where
     }
 }
 
+#[allow(clippy::needless_option_as_deref)]
 impl<T: PhysicalMemory, V: VirtualTranslate2, D: VirtualTranslate3> MemoryView
     for VirtualDma<T, V, D>
 {

--- a/memflow/src/mem/virt_mem/virtual_dma.rs
+++ b/memflow/src/mem/virt_mem/virtual_dma.rs
@@ -15,7 +15,7 @@ use crate::mem::{
 use crate::types::{umem, Address, PhysicalAddress};
 
 use bumpalo::{collections::Vec as BumpVec, Bump};
-use cglue::{callback::FromExtend, iter::CIterator};
+use cglue::callback::FromExtend;
 
 /// The VirtualDma struct provides a default implementation to access virtual memory
 /// from user provided [`PhysicalMemory`] and [`VirtualTranslate2`] objects.
@@ -191,48 +191,56 @@ impl<T: PhysicalMemory, V: VirtualTranslate2, D: VirtualTranslate3> MemoryView
 {
     fn read_raw_iter<'a>(
         &mut self,
-        data: CIterator<ReadData<'a>>,
-        out_fail: &mut ReadFailCallback<'_, 'a>,
+        MemOps {
+            inp,
+            out,
+            mut out_fail,
+        }: ReadRawMemOps,
     ) -> Result<()> {
         self.arena.reset();
-        // TODO: size_hint
-        let mut translation = BumpVec::with_capacity_in(data.size_hint().0, &self.arena);
+        let mut translation = BumpVec::with_capacity_in(inp.size_hint().0, &self.arena);
 
-        //let mut partial_read = false;
         self.vat.virt_to_phys_iter(
             &mut self.phys_mem,
             &self.translator,
-            data,
+            inp,
             &mut translation.from_extend(),
-            &mut (&mut |(_, rdata): (_, ReadData<'a>)| out_fail.call(rdata)).into(),
+            &mut (&mut |(_, MemData3(_, meta, buf)): (_, _)| {
+                opt_call(out_fail.as_deref_mut(), MemData2(meta, buf))
+            })
+                .into(),
         );
 
-        let mut iter = translation.into_iter();
-
-        self.phys_mem
-            .phys_read_raw_iter((&mut iter).into(), &mut (&mut |_| true).into())
+        MemOps::with_raw(translation.into_iter(), out, out_fail, |data| {
+            self.phys_mem.phys_read_raw_iter(data)
+        })
     }
 
-    fn write_raw_iter<'a>(
+    fn write_raw_iter(
         &mut self,
-        data: CIterator<WriteData<'a>>,
-        out_fail: &mut WriteFailCallback<'_, 'a>,
+        MemOps {
+            inp,
+            out,
+            mut out_fail,
+        }: WriteRawMemOps,
     ) -> Result<()> {
         self.arena.reset();
-        let mut translation = BumpVec::with_capacity_in(data.size_hint().0, &self.arena);
+        let mut translation = BumpVec::with_capacity_in(inp.size_hint().0, &self.arena);
 
         self.vat.virt_to_phys_iter(
             &mut self.phys_mem,
             &self.translator,
-            data,
+            inp,
             &mut translation.from_extend(),
-            &mut (&mut |(_, wdata): (_, WriteData<'a>)| out_fail.call(wdata)).into(),
+            &mut (&mut |(_, MemData3(_, meta, buf)): (_, _)| {
+                opt_call(out_fail.as_deref_mut(), MemData2(meta, buf))
+            })
+                .into(),
         );
 
-        let mut iter = translation.into_iter();
-
-        self.phys_mem
-            .phys_write_raw_iter((&mut iter).into(), &mut (&mut |_| true).into())
+        MemOps::with_raw(translation.into_iter(), out, out_fail, |data| {
+            self.phys_mem.phys_write_raw_iter(data)
+        })
     }
 
     fn metadata(&self) -> MemoryViewMetadata {
@@ -258,7 +266,7 @@ impl<T: PhysicalMemory, V: VirtualTranslate2, D: VirtualTranslate3> VirtualTrans
 {
     fn virt_to_phys_list(
         &mut self,
-        addrs: &[MemoryRange],
+        addrs: &[VtopRange],
         mut out: VirtualTranslationCallback,
         mut out_fail: VirtualTranslationFailCallback,
     ) {
@@ -267,16 +275,16 @@ impl<T: PhysicalMemory, V: VirtualTranslate2, D: VirtualTranslate3> VirtualTrans
             &self.translator,
             addrs
                 .iter()
-                .map(|&MemData(address, size)| MemData(address, (address, size))),
-            &mut (&mut |MemData(a, b): MemData<PhysicalAddress, (Address, umem)>| {
+                .map(|&MemData2(address, size)| MemData3(address, address, size)),
+            &mut (&mut |MemData3(a, b, c): MemData3<PhysicalAddress, Address, umem>| {
                 out.call(VirtualTranslation {
-                    in_virtual: b.0,
-                    size: b.1,
+                    in_virtual: b,
+                    size: c,
                     out_physical: a,
                 })
             })
                 .into(),
-            &mut (&mut |(_e, MemData(from, (_, size)))| {
+            &mut (&mut |(_e, MemData3(from, _, size))| {
                 out_fail.call(VirtualTranslationFail { from, size })
             })
                 .into(),

--- a/memflow/src/mem/virt_translate/direct_translate.rs
+++ b/memflow/src/mem/virt_translate/direct_translate.rs
@@ -1,6 +1,6 @@
 use super::{VirtualTranslate2, VirtualTranslate3, VtopFailureCallback, VtopOutputCallback};
 use crate::iter::SplitAtIndex;
-use crate::mem::{MemData, PhysicalMemory};
+use crate::mem::{MemData3, PhysicalMemory};
 use crate::types::{size, Address};
 use std::prelude::v1::*;
 
@@ -42,7 +42,7 @@ impl VirtualTranslate2 for DirectTranslate {
         T: PhysicalMemory + ?Sized,
         B: SplitAtIndex,
         D: VirtualTranslate3,
-        VI: Iterator<Item = MemData<Address, B>>,
+        VI: Iterator<Item = MemData3<Address, Address, B>>,
     {
         translator.virt_to_phys_iter(phys_mem, addrs, out, out_fail, &mut self.tmp_buf)
     }

--- a/memflow/src/mem/virt_translate/mmu/mod.rs
+++ b/memflow/src/mem/virt_translate/mmu/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod translate_data;
 
 use super::VtopFailureCallback;
 use crate::iter::SplitAtIndex;
-use crate::mem::MemData;
+use crate::mem::MemData3;
 use crate::types::{umem, Address};
 pub(crate) use def::ArchMmuDef;
 pub(crate) use fixed_slice_vec::FixedSliceVec as MVec;
@@ -29,7 +29,7 @@ pub trait MmuTranslationBase: Clone + Copy + core::fmt::Debug {
     fn virt_addr_filter<B: SplitAtIndex>(
         &self,
         spec: &ArchMmuSpec,
-        addr: MemData<Address, B>,
+        addr: MemData3<Address, Address, B>,
         work_group: (&mut TranslationChunk<Self>, &mut TranslateDataVec<B>),
         out_fail: &mut VtopFailureCallback<B>,
     );
@@ -43,7 +43,7 @@ pub trait MmuTranslationBase: Clone + Copy + core::fmt::Debug {
         work_vecs: &mut (TranslateVec, TranslateDataVec<B>),
         wait_vecs: &mut (TranslateVec, TranslateDataVec<B>),
     ) where
-        VI: Iterator<Item = MemData<Address, B>>,
+        VI: Iterator<Item = MemData3<Address, Address, B>>,
         B: SplitAtIndex,
     {
         let mut init_chunk = TranslationChunk::new(*self, FlagsType::NONE);
@@ -79,7 +79,7 @@ impl MmuTranslationBase for Address {
     fn virt_addr_filter<B>(
         &self,
         spec: &ArchMmuSpec,
-        addr: MemData<Address, B>,
+        addr: MemData3<Address, Address, B>,
         work_group: (&mut TranslationChunk<Self>, &mut TranslateDataVec<B>),
         out_fail: &mut VtopFailureCallback<B>,
     ) where

--- a/memflow/src/mem/virt_translate/mmu/translate_data.rs
+++ b/memflow/src/mem/virt_translate/mmu/translate_data.rs
@@ -25,6 +25,7 @@ unsafe fn shorten_pair_lifetime<'a: 't, 'b: 't, 't, O>(
 #[derive(Debug)]
 pub struct TranslateData<T> {
     pub addr: Address,
+    pub meta_addr: Address,
     pub buf: T,
 }
 
@@ -66,13 +67,19 @@ impl<T: SplitAtIndex> SplitAtIndex for TranslateData<T> {
         Self: Sized,
     {
         let addr = self.addr;
+        let meta_addr = self.meta_addr;
         let (bleft, bright) = self.buf.split_at(idx);
 
         (
-            bleft.map(|buf| TranslateData { addr, buf }),
+            bleft.map(|buf| TranslateData {
+                addr,
+                meta_addr,
+                buf,
+            }),
             bright.map(|buf| TranslateData {
                 buf,
                 addr: addr + idx,
+                meta_addr: meta_addr + idx,
             }),
         )
     }
@@ -82,13 +89,19 @@ impl<T: SplitAtIndex> SplitAtIndex for TranslateData<T> {
         Self: Sized,
     {
         let addr = self.addr;
+        let meta_addr = self.meta_addr;
         let (bleft, bright) = self.buf.split_at_mut(idx);
 
         (
-            bleft.map(|buf| TranslateData { addr, buf }),
+            bleft.map(|buf| TranslateData {
+                addr,
+                meta_addr,
+                buf,
+            }),
             bright.map(|buf| TranslateData {
                 buf,
                 addr: addr + idx,
+                meta_addr: meta_addr + idx,
             }),
         )
     }

--- a/memflow/src/mem/virt_translate/tests.rs
+++ b/memflow/src/mem/virt_translate/tests.rs
@@ -2,7 +2,7 @@ use crate::architecture::x86::x64;
 use crate::cglue::ForwardMut;
 use crate::dummy::{DummyMemory, DummyOs};
 use crate::mem::{
-    DirectTranslate, MemData, MemoryView, PhysicalMemory, VirtualDma, VirtualTranslate,
+    DirectTranslate, MemData3, MemoryView, PhysicalMemory, VirtualDma, VirtualTranslate,
     VirtualTranslate2, VirtualTranslate3,
 };
 use crate::types::{mem, size, PageType};
@@ -88,8 +88,8 @@ fn test_virt_page_map() {
 
     let page_map = virt_mem.virt_page_map_vec(0);
 
-    for MemData(address, size) in page_map.iter() {
-        println!("{:x}-{:x} ({:x})", address, *address + *size, size);
+    for MemData3(address, size, pt) in page_map.iter() {
+        println!("{:x}-{:x} ({:x}) {:?}", address, *address + *size, size, pt);
     }
 
     assert!(page_map.len() == 1);


### PR DESCRIPTION
This fixes various shortcomings/oversights in the current API, and it should be the final major breaking change before 0.2.

See #82 for the proposal.

Here is the list of problems we have, and how this PR solves them:

1. Memory Range API had no way to tell memory permissions - an extra `Page` field was added to the returned struct.
2. It becomes hard to reconstruct which reads succeeded, because only failed ones were reported back - add `out` callback for success cases.
   * This adds a bit of extra complexity, since every part of the chain needs to correctly report back errors/successes. Otherwise, any user who uses the success/failure capabilities may end up leaking data.
3. Allow passing `None`/`NULL` callbacks. This makes it easier for C users.
4. The `Address` in MemoryView's `out_fail` was unreliable, because the starting address would be lost along the way. This one is a little bigger:
   * We add an additional parameter - `meta_addr` which gets passed along the entire pipeline, and then returned back. This way the starting address never gets lost. `out_fail/out` contain only this `meta_addr` as opposed to the previous address we had.
   * PhysicalMemory callbacks are also of the same type as MemoryView's
   * Users are now advised to use `read_iter/write_iter` as opposed to `read_raw_iter/write_raw_iter`, because they mimic the old API
   * Here is an example flow:
```mermaid
sequenceDiagram
    participant user
    participant VirtualDma
    participant Vtop
    participant PhysicalMemory
    user->>VirtualDma: (0x40, 0x40, [0x1000])
    user->>VirtualDma: (0x10040, 0x10040, [0x1000])
    VirtualDma->>Vtop: (0x40, 0x40, [0x1000])
    VirtualDma->>Vtop: (0x10040, 0x10040, [0x1000])
    Vtop->>VirtualDma: Ok (Phys 0xde040, 0x40, [0xfc0])
    Vtop->>VirtualDma: Ok (Phys 0xdf000, 0x1000, [0x40])
    Vtop->>user: Err (0x10040, [0x1000])
    VirtualDma->>PhysicalMemory: (Phys 0xde040, 0x40, [0xfc0])
    VirtualDma->>PhysicalMemory: (Phys 0xdf000, 0x1000, [0x40])
    PhysicalMemory->>user: Ok(0x40, [0xfc0])
    PhysicalMemory->>user: Err(0x1000, [0x40])
```