### PR TITLE
fix(#68): refactor usage of bit mask u8 to be inclusive

### DIFF
--- a/memflow/src/architecture/x86/x32.rs
+++ b/memflow/src/architecture/x86/x32.rs
@@ -46,15 +46,15 @@ mod tests {
         let mask_addr = Address::invalid();
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 0),
-            Address::bit_mask(12..31).to_umem()
+            Address::bit_mask(12..=31).to_umem()
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 1),
-            Address::bit_mask(12..31).to_umem()
+            Address::bit_mask(12..=31).to_umem()
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 2),
-            Address::bit_mask(12..31).to_umem()
+            Address::bit_mask(12..=31).to_umem()
         );
     }
 

--- a/memflow/src/architecture/x86/x32_pae.rs
+++ b/memflow/src/architecture/x86/x32_pae.rs
@@ -46,7 +46,7 @@ mod tests {
         let mask_addr = Address::invalid();
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 0),
-            Address::bit_mask(5..35).to_umem()
+            Address::bit_mask(5..=35).to_umem()
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 1),

--- a/memflow/src/architecture/x86/x32_pae.rs
+++ b/memflow/src/architecture/x86/x32_pae.rs
@@ -50,11 +50,11 @@ mod tests {
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 1),
-            Address::bit_mask(12..35).to_umem()
+            Address::bit_mask(12..=35).to_umem()
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 2),
-            Address::bit_mask(12..35).to_umem()
+            Address::bit_mask(12..=35).to_umem()
         );
     }
 

--- a/memflow/src/architecture/x86/x64.rs
+++ b/memflow/src/architecture/x86/x64.rs
@@ -49,15 +49,15 @@ mod tests {
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 1),
-            Address::bit_mask(12..51).to_umem()
+            Address::bit_mask(12..=51).to_umem()
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 2),
-            Address::bit_mask(12..51).to_umem()
+            Address::bit_mask(12..=51).to_umem()
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 3),
-            Address::bit_mask(12..51).to_umem()
+            Address::bit_mask(12..=51).to_umem()
         );
     }
 

--- a/memflow/src/architecture/x86/x64.rs
+++ b/memflow/src/architecture/x86/x64.rs
@@ -45,7 +45,7 @@ mod tests {
         let mask_addr = Address::invalid();
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 0),
-            Address::bit_mask(12..51).to_umem()
+            Address::bit_mask(12..=51).to_umem()
         );
         assert_eq!(
             mmu.pte_addr_mask(mask_addr, 1),

--- a/memflow/src/mem/virt_translate/mmu/def.rs
+++ b/memflow/src/mem/virt_translate/mmu/def.rs
@@ -74,7 +74,7 @@ impl ArchMmuDef {
             } else {
                 self.pte_size.to_le().trailing_zeros() as u8
             };
-        let mask = Address::bit_mask(min..max);
+        let mask = Address::bit_mask(min..=max);
         pte_addr.to_umem() & umem::from_le(mask.to_umem())
     }
 

--- a/memflow/src/mem/virt_translate/mmu/spec.rs
+++ b/memflow/src/mem/virt_translate/mmu/spec.rs
@@ -69,7 +69,7 @@ impl ArchMmuSpec {
                 } else {
                     def.pte_size.to_le().trailing_zeros() as u8
                 };
-            let mask = Address::bit_mask_u8(min..max);
+            let mask = Address::bit_mask_u8(min..=max);
             pte_addr_masks[i] = mask.to_umem();
 
             pt_leaf_size[i] = def.pt_leaf_size(i);
@@ -77,8 +77,8 @@ impl ArchMmuSpec {
 
             let (min, max) = def.virt_addr_bit_range(i);
             virt_addr_bit_ranges[i] = (min, max);
-            virt_addr_masks[i] = Address::bit_mask_u8(0..(max - min - 1)).to_umem();
-            virt_addr_page_masks[i] = Address::bit_mask_u8(0..(max - 1)).to_umem();
+            virt_addr_masks[i] = Address::bit_mask_u8(0..=max - min - 1).to_umem();
+            virt_addr_page_masks[i] = Address::bit_mask_u8(0..=max - 1).to_umem();
 
             i += 1;
         }

--- a/memflow/src/mem/virt_translate/mmu/spec.rs
+++ b/memflow/src/mem/virt_translate/mmu/spec.rs
@@ -137,7 +137,7 @@ impl ArchMmuSpec {
 
         // Trim to virt address space limit
         let (left, reject) = tr_data
-            .split_inclusive_at(Address::bit_mask(0..(self.def.addr_size * 8 - 1)).to_umem());
+            .split_inclusive_at(Address::bit_mask(0..=(self.def.addr_size * 8 - 1)).to_umem());
         let left = left.unwrap();
 
         if let Some(data) = reject {
@@ -170,7 +170,8 @@ impl ArchMmuSpec {
             if let Some(higher) = higher {
                 // The upper half has to be all negative (all bits set), so compare the masks
                 // to see if it is the case.
-                let lhs = Address::bit_mask(virt_bit_range..(self.def.addr_size * 8 - 1)).to_umem();
+                let lhs =
+                    Address::bit_mask(virt_bit_range..=(self.def.addr_size * 8 - 1)).to_umem();
                 let rhs = higher.addr.to_umem() & lhs;
 
                 if (lhs ^ rhs) == 0 {

--- a/memflow/src/types/address.rs
+++ b/memflow/src/types/address.rs
@@ -729,7 +729,10 @@ mod tests {
         assert_eq!(Address::bit_mask_u8(21..=29).to_umem(), 0x3fe0_0000);
         assert_eq!(Address::bit_mask_u8(30..=38).to_umem(), 0x007f_c000_0000);
         assert_eq!(Address::bit_mask_u8(39..=47).to_umem(), 0xff80_0000_0000);
-        assert_eq!(Address::bit_mask_u8(12..=51).to_umem(), 0x000f_ffff_ffff_f000);
+        assert_eq!(
+            Address::bit_mask_u8(12..=51).to_umem(),
+            0x000f_ffff_ffff_f000
+        );
     }
 
     #[test]

--- a/memflow/src/types/address.rs
+++ b/memflow/src/types/address.rs
@@ -240,10 +240,14 @@ impl Address {
     ///
     /// println!("mask: {}", Address::bit_mask(0..11));
     /// ```
-    pub fn bit_mask<T: TryInto<u8>>(bits: ops::Range<T>) -> Address {
+    pub fn bit_mask<T: TryInto<u8>>(bits: ops::RangeInclusive<T>) -> Address
+    where
+        T: TryInto<u8>,
+        T: Copy,
+    {
         Address(
-            (!0 >> ((UMEM_BITS - 1) - bits.end.try_into().ok().unwrap()))
-                & !((1 << bits.start.try_into().ok().unwrap()) - 1),
+            (!0 >> ((UMEM_BITS - 1) - (*bits.end()).try_into().ok().unwrap()))
+                & !((1 << (*bits.start()).try_into().ok().unwrap()) - 1),
         )
     }
 
@@ -387,7 +391,10 @@ impl Address {
     /// let addr = Address::from(123456789);
     /// println!("bits[0..2] = {}", addr.extract_bits(0..2));
     /// ```
-    pub fn extract_bits<T: TryInto<u8>>(self, bits: ops::Range<T>) -> Address {
+    pub fn extract_bits<T: TryInto<u8>>(self, bits: ops::RangeInclusive<T>) -> Address
+    where
+        T: Copy,
+    {
         (self.0 & Address::bit_mask(bits).to_umem()).into()
     }
 
@@ -714,12 +721,12 @@ mod tests {
 
     #[test]
     fn test_bit_mask() {
-        assert_eq!(Address::bit_mask(0..11).to_umem(), 0xfff);
-        assert_eq!(Address::bit_mask(12..20).to_umem(), 0x001f_f000);
-        assert_eq!(Address::bit_mask(21..29).to_umem(), 0x3fe0_0000);
-        assert_eq!(Address::bit_mask(30..38).to_umem(), 0x007f_c000_0000);
-        assert_eq!(Address::bit_mask(39..47).to_umem(), 0xff80_0000_0000);
-        assert_eq!(Address::bit_mask(12..51).to_umem(), 0x000f_ffff_ffff_f000);
+        assert_eq!(Address::bit_mask(0..=11).to_umem(), 0xfff);
+        assert_eq!(Address::bit_mask(12..=20).to_umem(), 0x001f_f000);
+        assert_eq!(Address::bit_mask(21..=29).to_umem(), 0x3fe0_0000);
+        assert_eq!(Address::bit_mask(30..=38).to_umem(), 0x007f_c000_0000);
+        assert_eq!(Address::bit_mask(39..=47).to_umem(), 0xff80_0000_0000);
+        assert_eq!(Address::bit_mask(12..=51).to_umem(), 0x000f_ffff_ffff_f000);
     }
 
     #[test]

--- a/memflow/src/types/address.rs
+++ b/memflow/src/types/address.rs
@@ -238,7 +238,7 @@ impl Address {
     /// ```
     /// use memflow::types::Address;
     ///
-    /// println!("mask: {}", Address::bit_mask(0..11));
+    /// println!("mask: {}", Address::bit_mask(0..=11));
     /// ```
     pub fn bit_mask<T: TryInto<u8>>(bits: ops::RangeInclusive<T>) -> Address
     where
@@ -389,7 +389,7 @@ impl Address {
     /// use memflow::types::Address;
     ///
     /// let addr = Address::from(123456789);
-    /// println!("bits[0..2] = {}", addr.extract_bits(0..2));
+    /// println!("bits[0..2] = {}", addr.extract_bits(0..=2));
     /// ```
     pub fn extract_bits<T: TryInto<u8>>(self, bits: ops::RangeInclusive<T>) -> Address
     where

--- a/memflow/src/types/address.rs
+++ b/memflow/src/types/address.rs
@@ -255,7 +255,7 @@ impl Address {
     /// ```
     /// use memflow::types::Address;
     ///
-    /// println!("mask: {}", Address::bit_mask(0..11));
+    /// println!("mask: {}", Address::bit_mask_u8(0..=11));
     /// ```
     pub const fn bit_mask_u8(bits: ops::RangeInclusive<u8>) -> Address {
         Address((!0 >> (UMEM_BITS - 1 - *bits.end())) & !((1 << *bits.start()) - 1))

--- a/memflow/src/types/address.rs
+++ b/memflow/src/types/address.rs
@@ -257,8 +257,8 @@ impl Address {
     ///
     /// println!("mask: {}", Address::bit_mask(0..11));
     /// ```
-    pub const fn bit_mask_u8(bits: ops::Range<u8>) -> Address {
-        Address((!0 >> (UMEM_BITS - 1 - bits.end)) & !((1 << bits.start) - 1))
+    pub const fn bit_mask_u8(bits: ops::RangeInclusive<u8>) -> Address {
+        Address((!0 >> (UMEM_BITS - 1 - *bits.end())) & !((1 << *bits.start()) - 1))
     }
 
     /// Checks wether the address is zero or not.

--- a/memflow/src/types/address.rs
+++ b/memflow/src/types/address.rs
@@ -723,6 +723,16 @@ mod tests {
     }
 
     #[test]
+    fn test_bit_mask_u8() {
+        assert_eq!(Address::bit_mask_u8(0..=11).to_umem(), 0xfff);
+        assert_eq!(Address::bit_mask_u8(12..=20).to_umem(), 0x001f_f000);
+        assert_eq!(Address::bit_mask_u8(21..=29).to_umem(), 0x3fe0_0000);
+        assert_eq!(Address::bit_mask_u8(30..=38).to_umem(), 0x007f_c000_0000);
+        assert_eq!(Address::bit_mask_u8(39..=47).to_umem(), 0xff80_0000_0000);
+        assert_eq!(Address::bit_mask_u8(12..=51).to_umem(), 0x000f_ffff_ffff_f000);
+    }
+
+    #[test]
     fn test_ops() {
         assert_eq!(Address::from(10_u64) + 5usize, Address::from(15_u64));
 


### PR DESCRIPTION
Signed-off-by: Daniel Nehrig <daniel.nehrig@redteclab.com>
fix for #68