### PR TITLE
Add missing inline specifier in C header

### DIFF
--- a/memflow-ffi/bindgen.sh
+++ b/memflow-ffi/bindgen.sh
@@ -21,3 +21,7 @@ cargo +nightly install cglue-bindgen
 # generate c and cpp bindings
 run_twice rustup run nightly cglue-bindgen +nightly -c cglue.toml -- --config cbindgen.toml --crate memflow-ffi --output memflow.h -l C
 run_twice rustup run nightly cglue-bindgen +nightly -c cglue.toml -- --config cbindgen.toml --crate memflow-ffi --output memflow.hpp -l C++
+
+# temporary workaround
+sed -i 's/void ctx_arc_drop/static inline void ctx_arc_drop/i' memflow.h
+sed -i 's/void cont_box_drop/static inline void cont_box_drop/i' memflow.h

--- a/memflow-ffi/memflow.h
+++ b/memflow-ffi/memflow.h
@@ -2654,10 +2654,10 @@ static CArc_c_void ctx_arc_clone(CArc_c_void *self) {
     return ret;
 }
 
-void ctx_arc_drop(CArc_c_void *self) {
+static inline void ctx_arc_drop(CArc_c_void *self) {
     if (self->drop_fn && self->instance) self->drop_fn(self->instance);
 }
-void cont_box_drop(CBox_c_void *self) {
+static inline void cont_box_drop(CBox_c_void *self) {
     if (self->drop_fn && self->instance) self->drop_fn(self->instance);
 }
 


### PR DESCRIPTION
Since the `inline` specifier is missing for [`ctx_arc_drop`](
https://github.com/memflow/memflow/blob/db55eb598a63fb1f9856d437697c26cdc529ad44/memflow-ffi/memflow.h#L2657) and [`cont_box_drop`](https://github.com/memflow/memflow/blob/db55eb598a63fb1f9856d437697c26cdc529ad44/memflow-ffi/memflow.h#L2660), it's currently not possible to use the memflow C header in several files, as the linker would otherwise complain that the functions have been defined multiple times.

Unfortunately, I don't know how to configure `cglue-bindgen` in such a way that the result is achieved. Therefore I have - after a short conversation with @ko1N  - just added two `sed` calls to the `bindgen.sh` script as a temporary workaround.
