### PR TITLE
Add the ability to order operations performed by the batcher

### DIFF
--- a/memflow/src/mem/memory_view/batcher.rs
+++ b/memflow/src/mem/memory_view/batcher.rs
@@ -20,6 +20,8 @@ pub enum Ordering {
 
 /// A structure for batching memory reads and writes.
 ///
+/// By default, the batcher performs all reads before writes when committing to memory.
+///
 /// # Examples
 ///
 /// ```
@@ -108,9 +110,12 @@ impl<'a, T: MemoryView> MemoryViewBatcher<'a, T> {
         self
     }
 
-    /// Sets the ordering for memory operations performed by the batcher
-    pub fn set_ordering(&mut self, ordering: Ordering) {
+    /// Sets the ordering for memory operations performed by the batcher.
+    ///
+    /// You can either perform all reads before writes or vice versa by passing the corresponding `Ordering`.
+    pub fn with_ordering(&mut self, ordering: Ordering) -> &mut Self {
         self.ordering = ordering;
+        self
     }
 
     /// Executes all pending operations in this batch.

--- a/memflow/src/mem/memory_view/batcher.rs
+++ b/memflow/src/mem/memory_view/batcher.rs
@@ -113,7 +113,7 @@ impl<'a, T: MemoryView> MemoryViewBatcher<'a, T> {
     /// Sets the ordering for memory operations performed by the batcher.
     ///
     /// You can either perform all reads before writes or vice versa by passing the corresponding `Ordering`.
-    pub fn with_ordering(&mut self, ordering: Ordering) -> &mut Self {
+    pub fn with_ordering(mut self, ordering: Ordering) -> Self {
         self.ordering = ordering;
         self
     }


### PR DESCRIPTION
As it stands, there isn't a way to change the ordering in which memory operations are performed by the batcher when committed to memory.

This pull requests seeks to remedy this by keeping the prior default behavior of the batcher, but allows for people to change the behavior by explicitly setting the ordering (on the fly) before subsequent calls to `commit_rw()`.