### PR TITLE
add missing inner and inner_mut functions

### DIFF
--- a/memflow/src/mem/phys_mem/middleware/cache/mod.rs
+++ b/memflow/src/mem/phys_mem/middleware/cache/mod.rs
@@ -120,6 +120,14 @@ impl<'a, T: PhysicalMemory, Q: CacheValidator> CachedPhysicalMemory<'a, T, Q> {
     pub fn into_inner(self) -> T {
         self.mem
     }
+
+    pub fn inner(&self) -> &T {
+        &self.mem
+    }
+
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.mem
+    }
 }
 
 impl<'a, T: PhysicalMemory> CachedPhysicalMemory<'a, T, DefaultCacheValidator> {

--- a/memflow/src/mem/phys_mem/middleware/delay.rs
+++ b/memflow/src/mem/phys_mem/middleware/delay.rs
@@ -72,6 +72,14 @@ impl<T: PhysicalMemory> DelayedPhysicalMemory<T> {
     pub fn into_inner(self) -> T {
         self.mem
     }
+
+    pub fn inner(&self) -> &T {
+        &self.mem
+    }
+
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.mem
+    }
 }
 
 impl<T: PhysicalMemory> DelayedPhysicalMemory<T> {

--- a/memflow/src/mem/phys_mem/middleware/metrics.rs
+++ b/memflow/src/mem/phys_mem/middleware/metrics.rs
@@ -79,6 +79,14 @@ impl<T: PhysicalMemory> PhysicalMemoryMetrics<T> {
     pub fn into_inner(self) -> T {
         self.mem
     }
+
+    pub fn inner(&self) -> &T {
+        &self.mem
+    }
+
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.mem
+    }
 }
 
 // forward PhysicalMemory trait fncs


### PR DESCRIPTION
reason: it may be desired to access the underlying physical memory when wrapped in a middleware

example

```rs
let mut os = Win32Kernel::builder(connector)
    .build_default_caches()
    .build_page_cache(|connector, arch| {
        CachedPhysicalMemory::builder(connector)
            .arch(arch)
            .validator(UpsValidator::new())
            .cache_size(size::mb(64))
            .page_type_mask(PageType::all())
            .page_size(size::kb(4))
            .build()
            .unwrap()
    })
    .build()
    .unwrap();
```

```rs
pub fn read_no_cache<T: Pod + Sized>(&mut self, addr: Address) -> PartialResult<T> {
    // Use stack allocation for small types
    let mut uninit = std::mem::MaybeUninit::<T>::uninit();

    // Explicitly zero out the memory
    unsafe {
        std::ptr::write_bytes(uninit.as_mut_ptr(), 0, 1);
    }

    let buf = unsafe {
        std::slice::from_raw_parts_mut(uninit.as_mut_ptr() as *mut u8, std::mem::size_of::<T>())
    };

    let addr = self.virtual_translate(addr)?;
    Ok(
        self.process
            .virt_mem
            .phys_mem()
            .inner_mut() // function added by this pull request
            .phys_read_into(addr, buf)
    }
    .map(|_| {
        // Safety: Memory is zero-initialized and read_raw_into has read
        // whatever it could. It is now safe to assume_init for Pod types.
        unsafe { uninit.assume_init() }
    })?)
}
```